### PR TITLE
Add countBuilder and extendBuilder constructors to SliverStaggeredGrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.4
+* Add `countBuilder` and `extendBuilder` constructors to `SliverStaggeredGrid`
+
 ## 0.1.3
 * Remove Flutter SDK constraint
 

--- a/lib/src/sliver.dart
+++ b/lib/src/sliver.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
-
 import 'package:flutter_staggered_grid_view/src/sliver_staggered_grid.dart';
 import 'package:flutter_staggered_grid_view/src/staggered_tile.dart';
 
@@ -62,8 +61,7 @@ class SliverStaggeredGrid extends SliverMultiBoxAdaptorWidget {
     Key key,
     @required SliverChildDelegate delegate,
     @required this.gridDelegate,
-  })
-      : super(key: key, delegate: delegate);
+  }) : super(key: key, delegate: delegate);
 
   /// Creates a sliver that places multiple box children in a two dimensional
   /// arrangement with a fixed number of tiles in the cross axis.
@@ -81,8 +79,7 @@ class SliverStaggeredGrid extends SliverMultiBoxAdaptorWidget {
     double crossAxisSpacing: 0.0,
     List<Widget> children: const <Widget>[],
     List<StaggeredTile> staggeredTiles: const <StaggeredTile>[],
-  })
-      : gridDelegate = new SliverStaggeredGridDelegateWithFixedCrossAxisCount(
+  })  : gridDelegate = new SliverStaggeredGridDelegateWithFixedCrossAxisCount(
           crossAxisCount: crossAxisCount,
           mainAxisSpacing: mainAxisSpacing,
           crossAxisSpacing: crossAxisSpacing,
@@ -90,6 +87,45 @@ class SliverStaggeredGrid extends SliverMultiBoxAdaptorWidget {
           staggeredTileCount: staggeredTiles?.length,
         ),
         super(key: key, delegate: new SliverChildListDelegate(children));
+
+  /// Creates a sliver that builds multiple box children in a two dimensional
+  /// arrangement with a fixed number of tiles in the cross axis.
+  ///
+  /// This constructor is appropriate for grid views with a large (or infinite)
+  /// number of children because the builder is called only for those children
+  /// that are actually visible.
+  ///
+  /// Uses a [SliverStaggeredGridDelegateWithFixedCrossAxisCount] as the
+  /// [gridDelegate], and a [SliverChildBuilderDelegate] as the [delegate].
+  ///
+  /// See also:
+  ///
+  ///  * [new StaggeredGridView.countBuilder], the equivalent constructor for
+  ///  [StaggeredGridView] widgets.
+  SliverStaggeredGrid.countBuilder({
+    Key key,
+    @required int crossAxisCount,
+    @required IndexedStaggeredTileBuilder staggeredTileBuilder,
+    @required IndexedWidgetBuilder itemBuilder,
+    @required int itemCount,
+    double mainAxisSpacing: 0.0,
+    double crossAxisSpacing: 0.0,
+  })  : gridDelegate = new SliverStaggeredGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: crossAxisCount,
+          mainAxisSpacing: mainAxisSpacing,
+          crossAxisSpacing: crossAxisSpacing,
+          staggeredTileBuilder: staggeredTileBuilder,
+          staggeredTileCount: itemCount,
+        ),
+        super(
+          key: key,
+          delegate: SliverChildBuilderDelegate(
+            itemBuilder,
+            childCount: itemCount,
+            addAutomaticKeepAlives: true,
+            addRepaintBoundaries: true,
+          ),
+        );
 
   /// Creates a sliver that places multiple box children in a two dimensional
   /// arrangement with tiles that each have a maximum cross-axis extent.
@@ -107,8 +143,7 @@ class SliverStaggeredGrid extends SliverMultiBoxAdaptorWidget {
     double crossAxisSpacing: 0.0,
     List<Widget> children: const <Widget>[],
     List<StaggeredTile> staggeredTiles: const <StaggeredTile>[],
-  })
-      : gridDelegate = new SliverStaggeredGridDelegateWithMaxCrossAxisExtent(
+  })  : gridDelegate = new SliverStaggeredGridDelegateWithMaxCrossAxisExtent(
           maxCrossAxisExtent: maxCrossAxisExtent,
           mainAxisSpacing: mainAxisSpacing,
           crossAxisSpacing: crossAxisSpacing,
@@ -116,6 +151,45 @@ class SliverStaggeredGrid extends SliverMultiBoxAdaptorWidget {
           staggeredTileCount: staggeredTiles?.length,
         ),
         super(key: key, delegate: new SliverChildListDelegate(children));
+
+  /// Creates a sliver that builds multiple box children in a two dimensional
+  /// arrangement with tiles that each have a maximum cross-axis extent.
+  ///
+  /// This constructor is appropriate for grid views with a large (or infinite)
+  /// number of children because the builder is called only for those children
+  /// that are actually visible.
+  ///
+  /// Uses a [SliverStaggeredGridDelegateWithMaxCrossAxisExtent] as the
+  /// [gridDelegate], and a [SliverChildBuilderDelegate] as the [delegate].
+  ///
+  /// See also:
+  ///
+  ///  * [new StaggeredGridView.extentBuilder], the equivalent constructor for
+  ///  [StaggeredGridView] widgets.
+  SliverStaggeredGrid.extentBuilder({
+    Key key,
+    @required double maxCrossAxisExtent,
+    @required IndexedStaggeredTileBuilder staggeredTileBuilder,
+    @required IndexedWidgetBuilder itemBuilder,
+    @required int itemCount,
+    double mainAxisSpacing: 0.0,
+    double crossAxisSpacing: 0.0,
+  })  : gridDelegate = new SliverStaggeredGridDelegateWithMaxCrossAxisExtent(
+          maxCrossAxisExtent: maxCrossAxisExtent,
+          mainAxisSpacing: mainAxisSpacing,
+          crossAxisSpacing: crossAxisSpacing,
+          staggeredTileBuilder: staggeredTileBuilder,
+          staggeredTileCount: itemCount,
+        ),
+        super(
+          key: key,
+          delegate: SliverChildBuilderDelegate(
+            itemBuilder,
+            childCount: itemCount,
+            addAutomaticKeepAlives: true,
+            addRepaintBoundaries: true,
+          ),
+        );
 
   /// The delegate that controls the size and position of the children.
   final SliverStaggeredGridDelegate gridDelegate;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_staggered_grid_view
 description: A Flutter staggered grid view
-version: 0.1.3
+version: 0.1.4
 author: Romain Rastel <lets4r@gmail.com>
 homepage: https://github.com/letsar/flutter_staggered_grid_view
 dependencies:


### PR DESCRIPTION
Hey there! I was using this package and working with a Sliver + Infinite list, so I needed a "builder" version of the SliverStaggeredGrid. I was doing it on my own by providing my own `delegate` and `childDelegate`, but thought it might be nice for others to just use a constructor as it's a bit easier to understand / less code for consumers.

Lemme know whatcha think :)