### PR TITLE
Try to fixed #49 for error type 'SliverHitTestResult' is not a subtype of type 'BoxHitTestResult' 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0
+### Fixed
+* Fixed the BoxHitTestResult exception (https://github.com/letsar/flutter_staggered_grid_view/issues/49) again after flutter v1.7 since flutter has changed the function signature for `hitTestChildren`, check [old](https://github.com/flutter/flutter/blob/953bbe2ccd45461f9cafc7c060cf2297227631d0/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart#L481) and [new](https://github.com/flutter/flutter/blob/b712a172f9694745f50505c93340883493b505e5/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart#L560)
+
 ## 0.3.0
 ### Fixed
 * Upgrade to AndroidX and fixes the BoxHitTestResult exception (https://github.com/letsar/flutter_staggered_grid_view/issues/49)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ dependencies:
   flutter_staggered_grid_view: "^0.2.7"
 ```
 
+For flutter after v1.7, please use version after `0.4.0`, otherwise `0.3.0` or below.
+
 In your library add the following import:
 
 ```dart

--- a/lib/src/rendering/sliver_variable_size_box_adaptor.dart
+++ b/lib/src/rendering/sliver_variable_size_box_adaptor.dart
@@ -377,7 +377,7 @@ abstract class RenderSliverVariableSizeBoxAdaptor extends RenderSliver
   bool hitTestChildren(SliverHitTestResult result, 
       { @required double mainAxisPosition, @required double crossAxisPosition }) {
     for (var child in children) {
-      if (hitTestBoxChild(BoxHitTestResult.wrap(result), child,
+      if (hitTestBoxChild(BoxHitTestResult.wrap(HitTestResult.wrap(result)), child,
           mainAxisPosition: mainAxisPosition,
           crossAxisPosition: crossAxisPosition)) return true;
     }

--- a/lib/src/rendering/sliver_variable_size_box_adaptor.dart
+++ b/lib/src/rendering/sliver_variable_size_box_adaptor.dart
@@ -376,8 +376,9 @@ abstract class RenderSliverVariableSizeBoxAdaptor extends RenderSliver
   @override
   bool hitTestChildren(SliverHitTestResult result, 
       { @required double mainAxisPosition, @required double crossAxisPosition }) {
+    final BoxHitTestResult boxResult = BoxHitTestResult.wrap(result);
     for (var child in children) {
-      if (hitTestBoxChild(BoxHitTestResult.wrap(HitTestResult.wrap(result)), child,
+      if (hitTestBoxChild(boxResult, child,
           mainAxisPosition: mainAxisPosition,
           crossAxisPosition: crossAxisPosition)) return true;
     }

--- a/lib/src/rendering/sliver_variable_size_box_adaptor.dart
+++ b/lib/src/rendering/sliver_variable_size_box_adaptor.dart
@@ -374,8 +374,8 @@ abstract class RenderSliverVariableSizeBoxAdaptor extends RenderSliver
   }
 
   @override
-  bool hitTestChildren(HitTestResult result,
-      {@required double mainAxisPosition, @required double crossAxisPosition}) {
+  bool hitTestChildren(SliverHitTestResult result, 
+      { @required double mainAxisPosition, @required double crossAxisPosition }) {
     for (var child in children) {
       if (hitTestBoxChild(BoxHitTestResult.wrap(result), child,
           mainAxisPosition: mainAxisPosition,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_staggered_grid_view
 description: A Flutter staggered grid view
-version: 0.3.0
+version: 0.4.0
 author: Romain Rastel <lets4r@gmail.com>
 homepage: https://github.com/letsar/flutter_staggered_grid_view
 dependencies:
@@ -14,4 +14,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=1.19.0 <3.0.0"
-  flutter: ">=1.6.0"
+  flutter: ">=1.7.0"


### PR DESCRIPTION
After upgraded flutter to v1.7.8, #49 will occured. Checked codes from flutter, we can see [here](https://github.com/flutter/flutter/blob/953bbe2ccd45461f9cafc7c060cf2297227631d0/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart#L481) and [here](https://github.com/flutter/flutter/blob/b712a172f9694745f50505c93340883493b505e5/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart#L560). The signature for  method `hitTestChildren` has been changed. So I tried with these updates to make sure this plugin can work in flutter v1.7