### PR TITLE
Fixed a crash that happened when itemCount was not set and itemBuilder returned a null (to indicate the end of items).

### DIFF
--- a/lib/src/rendering/sliver_staggered_grid.dart
+++ b/lib/src/rendering/sliver_staggered_grid.dart
@@ -314,6 +314,11 @@ class RenderSliverStaggeredGrid extends RenderSliverVariableSizeBoxAdaptor {
         BoxConstraints constraints =
             new BoxConstraints.tightFor(width: geometry.crossAxisExtent);
         child = addAndLayoutChild(index, constraints, parentUsesSize: true);
+        if (child == null) {
+          // There are no children left.
+          reachedEnd = true;
+          break;
+        }
         geometry = geometry.copyWith(mainAxisExtent: paintExtentOf(child));
       }
 


### PR DESCRIPTION
This allows the developer to write a code like this (from Example_8.dart):

      ...
      body: new StaggeredGridView.countBuilder(
        primary: false,
        crossAxisCount: 4,
        mainAxisSpacing: 4.0,
        crossAxisSpacing: 4.0,
        itemBuilder: (context, index) => index < _sizes.length ? new _Tile(index, _sizes[index]) : null,
        staggeredTileBuilder: (index) => new StaggeredTile.fit(2),
      ),
     ...

Here itemCount is not set and we return a null when we've reached the end of tiles. With current code, this causes a crash.