### PR TITLE
Fixed StaggeredTile.fit with horizontal scrollDirection

### DIFF
--- a/example/lib/example_9.dart
+++ b/example/lib/example_9.dart
@@ -1,0 +1,156 @@
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+
+final Uint8List kTransparentImage = Uint8List.fromList(<int>[
+  0x89,
+  0x50,
+  0x4E,
+  0x47,
+  0x0D,
+  0x0A,
+  0x1A,
+  0x0A,
+  0x00,
+  0x00,
+  0x00,
+  0x0D,
+  0x49,
+  0x48,
+  0x44,
+  0x52,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x08,
+  0x06,
+  0x00,
+  0x00,
+  0x00,
+  0x1F,
+  0x15,
+  0xC4,
+  0x89,
+  0x00,
+  0x00,
+  0x00,
+  0x0A,
+  0x49,
+  0x44,
+  0x41,
+  0x54,
+  0x78,
+  0x9C,
+  0x63,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x05,
+  0x00,
+  0x01,
+  0x0D,
+  0x0A,
+  0x2D,
+  0xB4,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x49,
+  0x45,
+  0x4E,
+  0x44,
+  0xAE,
+]);
+
+List<IntSize> _createSizes(int count) {
+  final rnd = Random();
+  return List.generate(count, (i) => IntSize(rnd.nextInt(500) + 200, 200));
+}
+
+class Example09 extends StatelessWidget {
+  Example09() : _sizes = _createSizes(_kItemCount).toList();
+
+  static const int _kItemCount = 1000;
+  final List<IntSize> _sizes;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('random dynamic tile sizes'),
+      ),
+      body: StaggeredGridView.countBuilder(
+        scrollDirection: Axis.horizontal,
+        primary: false,
+        crossAxisCount: 4,
+        mainAxisSpacing: 4,
+        crossAxisSpacing: 4,
+        itemBuilder: (context, index) => _Tile(index, _sizes[index]),
+        staggeredTileBuilder: (index) => const StaggeredTile.fit(2),
+      ),
+    );
+  }
+}
+
+class IntSize {
+  const IntSize(this.width, this.height);
+
+  final int width;
+  final int height;
+}
+
+class _Tile extends StatelessWidget {
+  const _Tile(this.index, this.size);
+
+  final IntSize size;
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Column(
+        children: <Widget>[
+          Stack(
+            children: <Widget>[
+              //Center(child: CircularProgressIndicator()),
+              Center(
+                child: FadeInImage.memoryNetwork(
+                  placeholder: kTransparentImage,
+                  image: 'https://picsum.photos/${size.width}/${size.height}/',
+                ),
+              ),
+            ],
+          ),
+          Padding(
+            padding: const EdgeInsets.all(4),
+            child: Column(
+              children: <Widget>[
+                Text(
+                  'Image number $index',
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+                Text(
+                  'Width: ${size.width}',
+                  style: const TextStyle(color: Colors.grey),
+                ),
+                Text(
+                  'Height: ${size.height}',
+                  style: const TextStyle(color: Colors.grey),
+                ),
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/home.dart
+++ b/example/lib/home.dart
@@ -3,7 +3,7 @@ import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 
 import 'routes.dart';
 
-const List<StaggeredTile> _tiles = <StaggeredTile>[
+const List<StaggeredTile> _tiles = const <StaggeredTile>[
   StaggeredTile.count(2, 0.5),
   StaggeredTile.count(1, 1),
   StaggeredTile.count(1, 1),
@@ -23,7 +23,8 @@ const List<StaggeredTile> _tiles = <StaggeredTile>[
   StaggeredTile.count(1, 1),
   StaggeredTile.count(1, 1),
   StaggeredTile.count(1, 1),
-  //const StaggeredTile.count(1, 1),
+  StaggeredTile.count(1, 1),
+  //StaggeredTile.count(1, 1),
 ];
 
 List<Widget> _children = const <Widget>[
@@ -53,7 +54,8 @@ List<Widget> _children = const <Widget>[
   HomeTile('random tiles', Colors.pink, example05),
   HomeTile('dynamic resizing', Colors.pink, example06),
   HomeTile('dynamic tile sizes', Colors.pink, example07),
-  HomeTile('random dynamic tile sizes', Colors.pink, example08),
+  HomeTile('vertical random dynamic tile sizes', Colors.pink, example08),
+  HomeTile('hoizontal random dynamic tile sizes', Colors.pink, example09),
   //HomeTile('test', Colors.pink, exampleTests),
 ];
 

--- a/example/lib/routes.dart
+++ b/example/lib/routes.dart
@@ -8,6 +8,7 @@ import 'example_5.dart';
 import 'example_6.dart';
 import 'example_7.dart';
 import 'example_8.dart';
+import 'example_9.dart';
 import 'example_tests.dart';
 import 'home.dart';
 import 'spannable_count_count_page.dart';
@@ -39,6 +40,7 @@ const String example05 = '/example_05';
 const String example06 = '/example_06';
 const String example07 = '/example_07';
 const String example08 = '/example_08';
+const String example09 = '/example_09';
 const String exampleTests = '/example_tests';
 
 Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
@@ -65,5 +67,6 @@ Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
   example06: (BuildContext context) => Example06(),
   example07: (BuildContext context) => Example07(),
   example08: (BuildContext context) => Example08(),
+  example09: (BuildContext context) => Example09(),
   exampleTests: (BuildContext context) => ExampleTests(),
 };

--- a/lib/src/rendering/sliver_staggered_grid.dart
+++ b/lib/src/rendering/sliver_staggered_grid.dart
@@ -3,9 +3,8 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
-
-import 'package:flutter_staggered_grid_view/src/widgets/staggered_tile.dart';
 import 'package:flutter_staggered_grid_view/src/rendering/sliver_variable_size_box_adaptor.dart';
+import 'package:flutter_staggered_grid_view/src/widgets/staggered_tile.dart';
 
 /// Signature for a function that creates [StaggeredTile] for a given index.
 typedef IndexedStaggeredTileBuilder = StaggeredTile? Function(int index);
@@ -233,7 +232,9 @@ class RenderSliverStaggeredGrid extends RenderSliverVariableSizeBoxAdaptor {
   RenderSliverStaggeredGrid({
     required RenderSliverVariableSizeBoxChildManager childManager,
     required SliverStaggeredGridDelegate gridDelegate,
+    Axis scrollDirection = Axis.vertical,
   })  : _gridDelegate = gridDelegate,
+        _scrollDirection = scrollDirection,
         _pageSizeToViewportOffsets =
             HashMap<double, SplayTreeMap<int, _ViewportOffsets?>>(),
         super(childManager: childManager);
@@ -261,6 +262,14 @@ class RenderSliverStaggeredGrid extends RenderSliverVariableSizeBoxAdaptor {
       markNeedsLayout();
     }
     _gridDelegate = value;
+  }
+
+  Axis get scrollDirection => _scrollDirection;
+  Axis _scrollDirection;
+  set scrollDirection(Axis value) {
+    if (_scrollDirection == value) return;
+    if (value.runtimeType != _gridDelegate.runtimeType) markNeedsLayout();
+    _scrollDirection = value;
   }
 
   final HashMap<double, SplayTreeMap<int, _ViewportOffsets?>>
@@ -331,8 +340,9 @@ class RenderSliverStaggeredGrid extends RenderSliverVariableSizeBoxAdaptor {
       RenderBox? child;
       if (!hasTrailingScrollOffset) {
         // Layout the child to compute its tailingScrollOffset.
-        final constraints =
-            BoxConstraints.tightFor(width: geometry.crossAxisExtent);
+        final constraints = _scrollDirection == Axis.vertical
+            ? BoxConstraints.tightFor(width: geometry.crossAxisExtent)
+            : BoxConstraints.tightFor(height: geometry.crossAxisExtent);
         child = addAndLayoutChild(index, constraints, parentUsesSize: true);
         geometry = geometry.copyWith(mainAxisExtent: paintExtentOf(child!));
       }

--- a/lib/src/widgets/sliver.dart
+++ b/lib/src/widgets/sliver.dart
@@ -180,11 +180,6 @@ class SliverVariableSizeBoxAdaptorElement extends RenderObjectElement
     final newParentData = newChild?.renderObject?.parentData
         as SliverVariableSizeBoxAdaptorParentData?;
 
-    // set keepAlive to true in order to populate the cache
-    if (newParentData != null) {
-      newParentData.keepAlive = true;
-    }
-
     // Preserve the old layoutOffset if the renderObject was swapped out.
     if (oldParentData != newParentData &&
         oldParentData != null &&

--- a/lib/src/widgets/sliver.dart
+++ b/lib/src/widgets/sliver.dart
@@ -3,7 +3,6 @@ import 'dart:collection';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
-
 import 'package:flutter_staggered_grid_view/src/rendering/sliver_staggered_grid.dart';
 import 'package:flutter_staggered_grid_view/src/rendering/sliver_variable_size_box_adaptor.dart';
 import 'package:flutter_staggered_grid_view/src/widgets/staggered_tile.dart';
@@ -422,6 +421,7 @@ class SliverStaggeredGrid extends SliverVariableSizeBoxAdaptorWidget {
   /// arrangement.
   const SliverStaggeredGrid({
     Key? key,
+    Axis this.scrollDirection = Axis.vertical,
     required SliverChildDelegate delegate,
     required this.gridDelegate,
   }) : super(key: key, delegate: delegate);
@@ -437,6 +437,7 @@ class SliverStaggeredGrid extends SliverVariableSizeBoxAdaptorWidget {
   ///  * [StaggeredGridView.count], the equivalent constructor for [StaggeredGridView] widgets.
   SliverStaggeredGrid.count({
     Key? key,
+    this.scrollDirection = Axis.vertical,
     required int crossAxisCount,
     double mainAxisSpacing = 0.0,
     double crossAxisSpacing = 0.0,
@@ -472,6 +473,7 @@ class SliverStaggeredGrid extends SliverVariableSizeBoxAdaptorWidget {
   ///  [StaggeredGridView] widgets.
   SliverStaggeredGrid.countBuilder({
     Key? key,
+    this.scrollDirection = Axis.vertical,
     required int crossAxisCount,
     required IndexedStaggeredTileBuilder staggeredTileBuilder,
     required IndexedWidgetBuilder itemBuilder,
@@ -504,12 +506,13 @@ class SliverStaggeredGrid extends SliverVariableSizeBoxAdaptorWidget {
   ///  * [StaggeredGridView.extent], the equivalent constructor for [StaggeredGridView] widgets.
   SliverStaggeredGrid.extent({
     Key? key,
+    this.scrollDirection = Axis.vertical,
     required double maxCrossAxisExtent,
-    double mainAxisSpacing = 0,
-    double crossAxisSpacing = 0,
-    List<Widget> children = const <Widget>[],
-    List<StaggeredTile> staggeredTiles = const <StaggeredTile>[],
-  })  : gridDelegate = SliverStaggeredGridDelegateWithMaxCrossAxisExtent(
+    double mainAxisSpacing: 0,
+    double crossAxisSpacing: 0,
+    List<Widget> children: const <Widget>[],
+    List<StaggeredTile> staggeredTiles: const <StaggeredTile>[],
+  })  : gridDelegate = new SliverStaggeredGridDelegateWithMaxCrossAxisExtent(
           maxCrossAxisExtent: maxCrossAxisExtent,
           mainAxisSpacing: mainAxisSpacing,
           crossAxisSpacing: crossAxisSpacing,
@@ -539,6 +542,7 @@ class SliverStaggeredGrid extends SliverVariableSizeBoxAdaptorWidget {
   ///  [StaggeredGridView] widgets.
   SliverStaggeredGrid.extentBuilder({
     Key? key,
+    this.scrollDirection = Axis.vertical,
     required double maxCrossAxisExtent,
     required IndexedStaggeredTileBuilder staggeredTileBuilder,
     required IndexedWidgetBuilder itemBuilder,
@@ -562,17 +566,21 @@ class SliverStaggeredGrid extends SliverVariableSizeBoxAdaptorWidget {
 
   /// The delegate that controls the size and position of the children.
   final SliverStaggeredGridDelegate gridDelegate;
+  final Axis scrollDirection;
 
   @override
   RenderSliverStaggeredGrid createRenderObject(BuildContext context) {
     final element = context as SliverVariableSizeBoxAdaptorElement;
     return RenderSliverStaggeredGrid(
-        childManager: element, gridDelegate: gridDelegate);
+        childManager: element,
+        gridDelegate: gridDelegate,
+        scrollDirection: scrollDirection);
   }
 
   @override
   void updateRenderObject(
       BuildContext context, RenderSliverStaggeredGrid renderObject) {
     renderObject.gridDelegate = gridDelegate;
+    renderObject.scrollDirection = scrollDirection;
   }
 }

--- a/lib/src/widgets/staggered_grid_view.dart
+++ b/lib/src/widgets/staggered_grid_view.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
-
+import 'package:flutter_staggered_grid_view/src/rendering/sliver_staggered_grid.dart';
 import 'package:flutter_staggered_grid_view/src/widgets/sliver.dart';
 import 'package:flutter_staggered_grid_view/src/widgets/staggered_tile.dart';
-import 'package:flutter_staggered_grid_view/src/rendering/sliver_staggered_grid.dart';
 
 /// A scrollable, 2D array of widgets with variable sizes.
 ///
@@ -502,6 +501,7 @@ class StaggeredGridView extends BoxScrollView {
     return SliverStaggeredGrid(
       delegate: childrenDelegate,
       gridDelegate: gridDelegate,
+      scrollDirection: scrollDirection,
     );
   }
 }


### PR DESCRIPTION
Attempt to fix https://github.com/letsar/flutter_staggered_grid_view/issues/91 as described by @pfugwtg in https://github.com/letsar/flutter_staggered_grid_view/issues/30.

Not sure if the fix is sufficient. I've added a horizontal example based on the random dynamic tile sizes, but it sometimes seems like the cards get too wide. If you scroll away from the too-wide cards and back to them, they're fine.