### PR TITLE
Fix LateInitializationError: Local `firstIndex` has not been initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0-nullsafety.3
+### Fixed
+* LateInitializationError: Local `firstIndex` has not been initialized. (https://github.com/letsar/flutter_staggered_grid_view/issues/151)
+
 ## 0.4.0-nullsafety.2
 ### Added
 * Support for state restoration

--- a/lib/src/widgets/sliver.dart
+++ b/lib/src/widgets/sliver.dart
@@ -129,7 +129,11 @@ class SliverVariableSizeBoxAdaptorElement extends RenderObjectElement
       } else if (_didUnderflow) {
         firstIndex = _childElements.firstKey()!;
         lastIndex = _childElements.lastKey()! + 1;
+      } else {
+        firstIndex = _childElements.firstKey()!;
+        lastIndex = _childElements.lastKey()!;
       }
+
       for (int index = firstIndex; index <= lastIndex; ++index) {
         _currentlyUpdatingChildIndex = index;
         final Element? newChild =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_staggered_grid_view
 description: A Flutter staggered grid view (masonry tiles) which supports multiple columns with rows of varying sizes
-version: 0.4.0-nullsafety.2
+version: 0.4.0-nullsafety.3
 homepage: https://github.com/letsar/flutter_staggered_grid_view
 
 dependencies:


### PR DESCRIPTION
Fixes #151