### PR TITLE
Add option to disable keepAlives

### DIFF
--- a/lib/src/widgets/sliver.dart
+++ b/lib/src/widgets/sliver.dart
@@ -3,7 +3,6 @@ import 'dart:collection';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
-
 import 'package:flutter_staggered_grid_view/src/rendering/sliver_staggered_grid.dart';
 import 'package:flutter_staggered_grid_view/src/rendering/sliver_variable_size_box_adaptor.dart';
 import 'package:flutter_staggered_grid_view/src/widgets/staggered_tile.dart';
@@ -17,7 +16,11 @@ abstract class SliverVariableSizeBoxAdaptorWidget
   const SliverVariableSizeBoxAdaptorWidget({
     Key? key,
     required this.delegate,
+    this.addAutomaticKeepAlives = true,
   }) : super(key: key);
+
+  /// Whether to add keepAlives to children
+  final bool addAutomaticKeepAlives;
 
   /// The delegate that provides the children for this widget.
   ///
@@ -33,7 +36,10 @@ abstract class SliverVariableSizeBoxAdaptorWidget
 
   @override
   SliverVariableSizeBoxAdaptorElement createElement() =>
-      SliverVariableSizeBoxAdaptorElement(this);
+      SliverVariableSizeBoxAdaptorElement(
+        this,
+        addAutomaticKeepAlives: addAutomaticKeepAlives,
+      );
 
   @override
   RenderSliverVariableSizeBoxAdaptor createRenderObject(BuildContext context);
@@ -80,8 +86,12 @@ abstract class SliverVariableSizeBoxAdaptorWidget
 class SliverVariableSizeBoxAdaptorElement extends RenderObjectElement
     implements RenderSliverVariableSizeBoxChildManager {
   /// Creates an element that lazily builds children for the given widget.
-  SliverVariableSizeBoxAdaptorElement(SliverVariableSizeBoxAdaptorWidget widget)
+  SliverVariableSizeBoxAdaptorElement(SliverVariableSizeBoxAdaptorWidget widget,
+      {this.addAutomaticKeepAlives = true})
       : super(widget);
+
+  /// Whether to add keepAlives to children
+  final bool addAutomaticKeepAlives;
 
   @override
   SliverVariableSizeBoxAdaptorWidget get widget =>
@@ -182,7 +192,7 @@ class SliverVariableSizeBoxAdaptorElement extends RenderObjectElement
         as SliverVariableSizeBoxAdaptorParentData?;
 
     // set keepAlive to true in order to populate the cache
-    if (newParentData != null) {
+    if (addAutomaticKeepAlives && newParentData != null) {
       newParentData.keepAlive = true;
     }
 
@@ -424,13 +434,21 @@ class SliverStaggeredGrid extends SliverVariableSizeBoxAdaptorWidget {
     Key? key,
     required SliverChildDelegate delegate,
     required this.gridDelegate,
-  }) : super(key: key, delegate: delegate);
+    bool addAutomaticKeepAlives = true,
+  }) : super(
+          key: key,
+          delegate: delegate,
+          addAutomaticKeepAlives: addAutomaticKeepAlives,
+        );
 
   /// Creates a sliver that places multiple box children in a two dimensional
   /// arrangement with a fixed number of tiles in the cross axis.
   ///
   /// Uses a [SliverStaggeredGridDelegateWithFixedCrossAxisCount] as the [gridDelegate],
   /// and a [SliverVariableSizeChildListDelegate] as the [delegate].
+  ///
+  /// The `addAutomaticKeepAlives` argument corresponds to the
+  //  [SliverVariableSizeChildListDelegate.addAutomaticKeepAlives] property. The
   ///
   /// See also:
   ///
@@ -442,6 +460,7 @@ class SliverStaggeredGrid extends SliverVariableSizeBoxAdaptorWidget {
     double crossAxisSpacing = 0.0,
     List<Widget> children = const <Widget>[],
     List<StaggeredTile> staggeredTiles = const <StaggeredTile>[],
+    bool addAutomaticKeepAlives = true,
   })  : gridDelegate = SliverStaggeredGridDelegateWithFixedCrossAxisCount(
           crossAxisCount: crossAxisCount,
           mainAxisSpacing: mainAxisSpacing,
@@ -453,6 +472,7 @@ class SliverStaggeredGrid extends SliverVariableSizeBoxAdaptorWidget {
           key: key,
           delegate: SliverChildListDelegate(
             children,
+            addAutomaticKeepAlives: addAutomaticKeepAlives,
           ),
         );
 
@@ -478,6 +498,7 @@ class SliverStaggeredGrid extends SliverVariableSizeBoxAdaptorWidget {
     required int itemCount,
     double mainAxisSpacing = 0,
     double crossAxisSpacing = 0,
+    bool addAutomaticKeepAlives = true,
   })  : gridDelegate = SliverStaggeredGridDelegateWithFixedCrossAxisCount(
           crossAxisCount: crossAxisCount,
           mainAxisSpacing: mainAxisSpacing,
@@ -490,6 +511,7 @@ class SliverStaggeredGrid extends SliverVariableSizeBoxAdaptorWidget {
           delegate: SliverChildBuilderDelegate(
             itemBuilder,
             childCount: itemCount,
+            addAutomaticKeepAlives: addAutomaticKeepAlives,
           ),
         );
 
@@ -509,6 +531,7 @@ class SliverStaggeredGrid extends SliverVariableSizeBoxAdaptorWidget {
     double crossAxisSpacing = 0,
     List<Widget> children = const <Widget>[],
     List<StaggeredTile> staggeredTiles = const <StaggeredTile>[],
+    bool addAutomaticKeepAlives = true,
   })  : gridDelegate = SliverStaggeredGridDelegateWithMaxCrossAxisExtent(
           maxCrossAxisExtent: maxCrossAxisExtent,
           mainAxisSpacing: mainAxisSpacing,
@@ -520,6 +543,7 @@ class SliverStaggeredGrid extends SliverVariableSizeBoxAdaptorWidget {
           key: key,
           delegate: SliverChildListDelegate(
             children,
+            addAutomaticKeepAlives: addAutomaticKeepAlives,
           ),
         );
 
@@ -545,6 +569,7 @@ class SliverStaggeredGrid extends SliverVariableSizeBoxAdaptorWidget {
     required int itemCount,
     double mainAxisSpacing = 0,
     double crossAxisSpacing = 0,
+    bool addAutomaticKeepAlives = true,
   })  : gridDelegate = SliverStaggeredGridDelegateWithMaxCrossAxisExtent(
           maxCrossAxisExtent: maxCrossAxisExtent,
           mainAxisSpacing: mainAxisSpacing,
@@ -557,6 +582,7 @@ class SliverStaggeredGrid extends SliverVariableSizeBoxAdaptorWidget {
           delegate: SliverChildBuilderDelegate(
             itemBuilder,
             childCount: itemCount,
+            addAutomaticKeepAlives: addAutomaticKeepAlives,
           ),
         );
 

--- a/lib/src/widgets/staggered_grid_view.dart
+++ b/lib/src/widgets/staggered_grid_view.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
-
+import 'package:flutter_staggered_grid_view/src/rendering/sliver_staggered_grid.dart';
 import 'package:flutter_staggered_grid_view/src/widgets/sliver.dart';
 import 'package:flutter_staggered_grid_view/src/widgets/staggered_tile.dart';
-import 'package:flutter_staggered_grid_view/src/rendering/sliver_staggered_grid.dart';
 
 /// A scrollable, 2D array of widgets with variable sizes.
 ///
@@ -133,7 +132,7 @@ class StaggeredGridView extends BoxScrollView {
     bool shrinkWrap = false,
     EdgeInsetsGeometry? padding,
     required this.gridDelegate,
-    bool addAutomaticKeepAlives = true,
+    this.addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     List<Widget> children = const <Widget>[],
     String? restorationId,
@@ -185,7 +184,7 @@ class StaggeredGridView extends BoxScrollView {
     required this.gridDelegate,
     required IndexedWidgetBuilder itemBuilder,
     int? itemCount,
-    bool addAutomaticKeepAlives = true,
+    this.addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     String? restorationId,
   })  : childrenDelegate = SliverChildBuilderDelegate(
@@ -226,6 +225,7 @@ class StaggeredGridView extends BoxScrollView {
     String? restorationId,
     required this.gridDelegate,
     required this.childrenDelegate,
+    this.addAutomaticKeepAlives = true,
   }) : super(
           key: key,
           scrollDirection: scrollDirection,
@@ -265,7 +265,7 @@ class StaggeredGridView extends BoxScrollView {
     required int crossAxisCount,
     double mainAxisSpacing = 0.0,
     double crossAxisSpacing = 0.0,
-    bool addAutomaticKeepAlives = true,
+    this.addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     List<Widget> children = const <Widget>[],
     List<StaggeredTile> staggeredTiles = const <StaggeredTile>[],
@@ -331,7 +331,7 @@ class StaggeredGridView extends BoxScrollView {
     int? itemCount,
     double mainAxisSpacing = 0.0,
     double crossAxisSpacing = 0.0,
-    bool addAutomaticKeepAlives = true,
+    this.addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     String? restorationId,
   })  : gridDelegate = SliverStaggeredGridDelegateWithFixedCrossAxisCount(
@@ -392,7 +392,7 @@ class StaggeredGridView extends BoxScrollView {
     required double maxCrossAxisExtent,
     double mainAxisSpacing = 0.0,
     double crossAxisSpacing = 0.0,
-    bool addAutomaticKeepAlives = true,
+    this.addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     List<Widget> children = const <Widget>[],
     List<StaggeredTile> staggeredTiles = const <StaggeredTile>[],
@@ -454,7 +454,7 @@ class StaggeredGridView extends BoxScrollView {
     int? itemCount,
     double mainAxisSpacing = 0.0,
     double crossAxisSpacing = 0.0,
-    bool addAutomaticKeepAlives = true,
+    this.addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     String? restorationId,
   })  : gridDelegate = SliverStaggeredGridDelegateWithMaxCrossAxisExtent(
@@ -497,11 +497,15 @@ class StaggeredGridView extends BoxScrollView {
   /// the given child list.
   final SliverChildDelegate childrenDelegate;
 
+  /// Whether to add keepAlives to children
+  final bool addAutomaticKeepAlives;
+
   @override
   Widget buildChildLayout(BuildContext context) {
     return SliverStaggeredGrid(
       delegate: childrenDelegate,
       gridDelegate: gridDelegate,
+      addAutomaticKeepAlives: addAutomaticKeepAlives,
     );
   }
 }


### PR DESCRIPTION
This MR is a complementary to #153.

It adds the option to disable the keepAlives (caching) for grid children.

The reason for this MR is to allow infinite grids 
as well as grids with cached images (e.g. cached_network_image)
without causing the app to crash because of uncleared memory.

Currently, using infinite image grids will result in rising RAM until the app is killed by the OS.
Here is an image from debug tools showing the memory usage for the current behaviour:
![66787935](https://user-images.githubusercontent.com/11785085/124394123-3988c280-dcfe-11eb-9bac-1fec12ca2f4d.png)
as seen, memory usage is around 3GB. The memory is never cleared, meaning the user will scroll into an app crash with infinite grids.

Here is an image of the memory usage with keepAlives disabled, same conditions:
![52562160](https://user-images.githubusercontent.com/11785085/124394145-6046f900-dcfe-11eb-9681-4f3978046dea.png)
the memory usage reaches a similar peak, then however is cleared up and caves in. This cave in is missing with keepAlives enabled.

I have written code to reproduce this behaviour.
creating a new flutter project with these dependencies:

```yaml
  cached_network_image: ^3.0.0
  flutter_staggered_grid_view:
    git:
      url: git://github.com/clragon/flutter_staggered_grid_view.git
      ref: master
```

and the following code in `main.dart`:

```dart
import 'dart:math';

import 'package:cached_network_image/cached_network_image.dart';
import 'package:flutter/material.dart';
import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';

void main() {
  runApp(MyApp());
}

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Grid Test',
      theme: ThemeData(
        primarySwatch: Colors.blue,
      ),
      home: GridTest(),
    );
  }
}

// enable or disable to test keepAlives
final bool keepAlives = true;

class GridTest extends StatefulWidget {
  const GridTest();

  @override
  _GridTestState createState() => _GridTestState();
}

class _GridTestState extends State<GridTest> {
  final Random rng = Random();

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: Text('Grid Test ' +
            (keepAlives ? 'with keepAlives' : 'without keepAlives')),
      ),
      body: StaggeredGridView.countBuilder(
        addAutomaticKeepAlives: keepAlives,
        crossAxisCount: 2,
        staggeredTileBuilder: (context) => StaggeredTile.count(1, 1),
        itemBuilder: (context, index) {
          int width = rng.nextInt(2000) + 500;
          int height = rng.nextInt(2000) + 500;
          print('[debug] building tile $index with pic dim $width/$height');
          return Card(
            child: Column(
              crossAxisAlignment: CrossAxisAlignment.stretch,
              children: [
                Expanded(
                  child: CachedNetworkImage(
                    imageUrl: 'https://picsum.photos/$width/$height',
                    fit: BoxFit.cover,
                  ),
                ),
              ],
            ),
          );
        },
      ),
    );
  }
}
```

The `keepAlives` boolean can be set to test either behaviour. 
The tests above were run on windows 10 and in each instance the grid was scrolled to ~ tile 1000.