### PR TITLE
Use `flutter pub add` to add as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,8 @@ Provides a collection of Flutter grids layouts.
 
 In the `pubspec.yaml` of your flutter project, add the following dependency:
 
-```yaml
-dependencies:
-  ...
-  flutter_staggered_grid_view: <latest_version>
+```console
+$ flutter pub add flutter_staggered_grid_view
 ```
 
 In your library add the following import:


### PR DESCRIPTION
The dart pub command debuted in Dart 2.10. Although you might still find examples of using the standalone pub command instead of dart pub or flutter pub, the standalone pub command is deprecated.