### PR TITLE
Minor change: nullability

### DIFF
--- a/lib/src/rendering/sliver_masonry_grid.dart
+++ b/lib/src/rendering/sliver_masonry_grid.dart
@@ -539,7 +539,7 @@ class RenderSliverMasonryGrid extends RenderSliverMultiBoxAdaptor {
           // We are missing a child. Insert it (and lay it out) if possible.
           child = insertAndLayoutChild(
             childConstraints,
-            after: trailingChildWithLayout,
+            after: trailingChildWithLayout!,
             parentUsesSize: true,
           );
           if (child == null) {


### PR DESCRIPTION
Context: https://github.com/flutter/flutter/pull/113246#issuecomment-1273964248

In short: The `after` in `insertAndLayoutChild` seems nullable at the first glance, but indeed the code `assert(after!=null)` inside that function, so we should never provide a null to it.