### PR TITLE
feat(reorderable): add ReorderableStaggeredGrid with drag-to-reorder,  and cell-aware drops

### DIFF
--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -1,14 +1,17 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+    id 'dev.flutter.flutter-gradle-plugin'
+}
+
+import java.util.Properties
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -21,20 +24,17 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-
 android {
-    compileSdkVersion 33
+    namespace = "com.example.examples"
+    compileSdk = flutter.compileSdkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     sourceSets {
@@ -42,27 +42,23 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.examples"
         minSdkVersion flutter.minSdkVersion
-        targetSdkVersion 33
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
+            signingConfig = signingConfigs.debug
         }
     }
 }
 
 flutter {
-    source '../..'
+    source = '../..'
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -44,8 +44,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.examples"
-        minSdkVersion 16
-        targetSdkVersion 30
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -26,6 +26,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace = "com.example.examples"
+    ndkVersion = "28.2.13676358"
     compileSdk = flutter.compileSdkVersion
 
     compileOptions {

--- a/examples/android/app/src/main/AndroidManifest.xml
+++ b/examples/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues

--- a/examples/android/build.gradle
+++ b/examples/android/build.gradle
@@ -1,12 +1,13 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    // Updated for newer Gradle/AGP compatibility
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -24,6 +25,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register("clean", Delete) {
+    delete rootProject.layout.buildDirectory
 }

--- a/examples/android/build.gradle
+++ b/examples/android/build.gradle
@@ -1,13 +1,13 @@
 buildscript {
     // Updated for newer Gradle/AGP compatibility
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.8.22'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/examples/android/build.gradle
+++ b/examples/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.6.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/examples/android/build.gradle
+++ b/examples/android/build.gradle
@@ -1,13 +1,13 @@
 buildscript {
     // Updated for newer Gradle/AGP compatibility
-    ext.kotlin_version = '1.8.22'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.6.0'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,3 +1,7 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4g
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/examples/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/examples/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/examples/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip

--- a/examples/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/examples/android/settings.gradle
+++ b/examples/android/settings.gradle
@@ -24,7 +24,7 @@ plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
 
     // Android & Kotlin plugins (declare but don't apply here)
-    id "com.android.application" version "8.1.1" apply false
+    id "com.android.application" version "8.6.0" apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 

--- a/examples/android/settings.gradle
+++ b/examples/android/settings.gradle
@@ -24,8 +24,8 @@ plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
 
     // Android & Kotlin plugins (declare but don't apply here)
-    id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ':app'

--- a/examples/android/settings.gradle
+++ b/examples/android/settings.gradle
@@ -1,11 +1,31 @@
+// Auto-migrated settings.gradle to use the declarative plugins block
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }
+    settings.ext.flutterSdkPath = flutterSdkPath()
+
+    // Make Flutter's gradle plugins available to the settings script
+    includeBuild("${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    // Flutter's plugin loader
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+
+    // Android & Kotlin plugins (declare but don't apply here)
+    id "com.android.application" version "8.1.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+}
+
 include ':app'
-
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
-
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
-
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"

--- a/examples/lib/examples/staggered.dart
+++ b/examples/lib/examples/staggered.dart
@@ -2,47 +2,54 @@ import 'package:examples/common.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 
-class StaggeredPage extends StatelessWidget {
-  const StaggeredPage({
-    Key? key,
-  }) : super(key: key);
+class StaggeredPage extends StatefulWidget {
+  const StaggeredPage({Key? key}) : super(key: key);
+
+  @override
+  _StaggeredPageState createState() => _StaggeredPageState();
+}
+
+class _StaggeredPageState extends State<StaggeredPage> {
+  final List<Map<String, dynamic>> items = [
+    {'id': 0, 'cross': 2, 'main': 2},
+    {'id': 1, 'cross': 2, 'main': 1},
+    {'id': 2, 'cross': 1, 'main': 1},
+    {'id': 3, 'cross': 1, 'main': 1},
+    {'id': 4, 'cross': 4, 'main': 2},
+  ];
+
+  void _onReorder(int oldIndex, int newIndex) {
+    setState(() {
+      final item = items.removeAt(oldIndex);
+      items.insert(newIndex, item);
+    });
+  }
+
+  void _onResize(int index, int newCross, num? newMain) {
+    setState(() {
+      items[index]['cross'] = newCross;
+      if (newMain != null) items[index]['main'] = newMain;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return AppScaffold(
-      title: 'Staggered',
+      title: 'Staggered (reorderable)',
       child: SingleChildScrollView(
-        child: StaggeredGrid.count(
+        child: ReorderableStaggeredGrid(
           crossAxisCount: 4,
-          mainAxisSpacing: 4,
-          crossAxisSpacing: 4,
-          children: const [
-            StaggeredGridTile.count(
-              crossAxisCellCount: 2,
-              mainAxisCellCount: 2,
-              child: Tile(index: 0),
-            ),
-            StaggeredGridTile.count(
-              crossAxisCellCount: 2,
-              mainAxisCellCount: 1,
-              child: Tile(index: 1),
-            ),
-            StaggeredGridTile.count(
-              crossAxisCellCount: 1,
-              mainAxisCellCount: 1,
-              child: Tile(index: 2),
-            ),
-            StaggeredGridTile.count(
-              crossAxisCellCount: 1,
-              mainAxisCellCount: 1,
-              child: Tile(index: 3),
-            ),
-            StaggeredGridTile.count(
-              crossAxisCellCount: 4,
-              mainAxisCellCount: 2,
-              child: Tile(index: 4),
-            ),
-          ],
+          mainAxisSpacing: 8,
+          crossAxisSpacing: 8,
+          onReorder: _onReorder,
+          onResize: _onResize,
+          children: items
+              .map((it) => StaggeredGridTile.count(
+                    crossAxisCellCount: it['cross'] as int,
+                    mainAxisCellCount: it['main'] as num,
+                    child: Tile(index: it['id'] as int),
+                  ))
+              .toList(),
         ),
       ),
     );

--- a/examples/lib/main.dart
+++ b/examples/lib/main.dart
@@ -122,7 +122,7 @@ class MenuEntry extends StatelessWidget {
                       textAlign: TextAlign.center,
                       style: Theme.of(context)
                           .textTheme
-                          .headline6!
+                          .titleLarge!
                           .copyWith(color: Colors.white),
                     ),
                   ),

--- a/examples/lib/main_examples.dart
+++ b/examples/lib/main_examples.dart
@@ -122,7 +122,7 @@ class MenuEntry extends StatelessWidget {
                       textAlign: TextAlign.center,
                       style: Theme.of(context)
                           .textTheme
-                          .headline6!
+                          .titleLarge!
                           .copyWith(color: Colors.white),
                     ),
                   ),

--- a/lib/flutter_staggered_grid_view.dart
+++ b/lib/flutter_staggered_grid_view.dart
@@ -11,3 +11,4 @@ export 'src/widgets/sliver_aligned_grid.dart';
 export 'src/widgets/sliver_masonry_grid.dart';
 export 'src/widgets/staggered_grid.dart';
 export 'src/widgets/staggered_grid_tile.dart';
+export 'src/widgets/reorderable_staggered_grid.dart';

--- a/lib/src/widgets/reorderable_staggered_grid.dart
+++ b/lib/src/widgets/reorderable_staggered_grid.dart
@@ -54,6 +54,8 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
   double _initialHeight = 0.0;
   bool _scalingActive = false;
   final List<GlobalKey> _childKeys = []; 
+  int? _hoverIndex;
+  int? _draggingIndex;
 
   @override
   Widget build(BuildContext context) {
@@ -110,9 +112,9 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
           ),
         ),
         childWhenDragging: Opacity(opacity: 0.25, child: tileContent),
-        onDragStarted: () {},
-        onDraggableCanceled: (_, __) {},
-        onDragEnd: (_) { setState(() { _hoverIndex = null; }); },
+        onDragStarted: () { setState(() { _draggingIndex = i; }); },
+        onDraggableCanceled: (_, __) { setState(() { _draggingIndex = null; _hoverIndex = null; }); },
+        onDragEnd: (_) { setState(() { _draggingIndex = null; _hoverIndex = null; }); },
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 150),
           decoration: _hoverIndex == i
@@ -187,7 +189,7 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
 
         // Derive a reasonable cell height from existing tiles: use tiles that
         // declare mainAxisCellCount or infer from their measured height.
-        double? cellHeight;
+        double cellHeight;
         final measuredHeights = <double>[];
         for (var i = 0; i < _childKeys.length; i++) {
           final key = _childKeys[i];
@@ -223,11 +225,11 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
           if (w is StaggeredGridTile) {
             if (w.mainAxisCellCount != null) return w.mainAxisCellCount!.toInt();
             if (w.mainAxisExtent != null) {
-              return (w.mainAxisExtent! / cellHeight).round().clamp(1, 9999);
+              return ((w.mainAxisExtent! / cellHeight).round().clamp(1, 9999)).toInt();
             }
           }
           if (render != null) {
-            return (render.size.height / cellHeight).round().clamp(1, 9999);
+            return ((render.size.height / cellHeight).round().clamp(1, 9999)).toInt();
           }
           return 1;
         }
@@ -346,7 +348,7 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
                 child: DragTarget<int>(
                   onMove: (details) {
                     setState(() {
-                      _hoverIndex = _indexForGlobalOffset(details.offset);
+                      _hoverIndex = _indexForGlobalOffset(details.offset, _draggingIndex ?? -1);
                     });
                   },
                   onLeave: (data) {
@@ -356,7 +358,7 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
                   },
                   onWillAccept: (data) => true,
                   onAcceptWithDetails: (details) {
-                    final newIndex = _indexForGlobalOffset(details.offset);
+                    final newIndex = _indexForGlobalOffset(details.offset, details.data);
                     setState(() {
                       _hoverIndex = null;
                     });

--- a/lib/src/widgets/reorderable_staggered_grid.dart
+++ b/lib/src/widgets/reorderable_staggered_grid.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_staggered_grid_view/src/widgets/staggered_grid.dart';
+import 'package:flutter_staggered_grid_view/src/widgets/staggered_grid_tile.dart';
+
+/// A simple helper that provides programmatic reorder/resize controls for
+/// staggered grid children. This is intentionally lightweight: it exposes
+/// onReorder and onResize callbacks so the parent can update the underlying
+/// data and rebuild the grid.
+class ReorderableStaggeredGrid extends StatelessWidget {
+  const ReorderableStaggeredGrid({
+    Key? key,
+    required this.children,
+    required this.onReorder,
+    this.onResize,
+    this.crossAxisCount = 4,
+    this.mainAxisSpacing = 4.0,
+    this.crossAxisSpacing = 4.0,
+  }) : super(key: key);
+
+  final List<Widget> children;
+  final void Function(int oldIndex, int newIndex) onReorder;
+  final void Function(int index, int crossAxisCellCount, num? mainAxisCellCount)?
+      onResize;
+  final int crossAxisCount;
+  final double mainAxisSpacing;
+  final double crossAxisSpacing;
+
+  @override
+  Widget build(BuildContext context) {
+    // Wrap each child with simple controls for move up / move down and resize.
+    // If the provided child is a StaggeredGridTile, recreate it and wrap its
+    // inner child so the ParentDataWidget remains the direct child of the
+    // StaggeredGrid (this preserves layout behavior).
+    final wrapped = List<Widget>.generate(children.length, (i) {
+      final original = children[i];
+
+      // Build control overlay to be placed inside the tile's child.
+      Widget buildWithOverlay(Widget inner) {
+        return _ControlWrapper(
+          index: i,
+          child: inner,
+          onMoveUp: i > 0 ? () => onReorder(i, i - 1) : null,
+          onMoveDown: i < children.length - 1 ? () => onReorder(i, i + 1) : null,
+          onIncreaseWidth: onResize == null
+              ? null
+              : () {
+                  final tile = _extractTile(original);
+                  final newCross = (tile?.crossAxisCellCount ?? 1) + 1;
+                  onResize!(i, newCross, tile?.mainAxisCellCount);
+                },
+          onDecreaseWidth: onResize == null
+              ? null
+              : () {
+                  final tile = _extractTile(original);
+                  final newCross = (tile?.crossAxisCellCount ?? 1) - 1;
+                  onResize!(i, newCross < 1 ? 1 : newCross, tile?.mainAxisCellCount);
+                },
+        );
+      }
+
+      if (original is StaggeredGridTile) {
+        // Recreate the tile with the inner child wrapped by the controls.
+        final inner = original.child;
+        if (original.mainAxisExtent != null) {
+          return StaggeredGridTile.extent(
+            crossAxisCellCount: original.crossAxisCellCount,
+            mainAxisExtent: original.mainAxisExtent!,
+            child: buildWithOverlay(inner),
+          );
+        } else if (original.mainAxisCellCount != null) {
+          return StaggeredGridTile.count(
+            crossAxisCellCount: original.crossAxisCellCount,
+            mainAxisCellCount: original.mainAxisCellCount!,
+            child: buildWithOverlay(inner),
+          );
+        } else {
+          return StaggeredGridTile.fit(
+            crossAxisCellCount: original.crossAxisCellCount,
+            child: buildWithOverlay(inner),
+          );
+        }
+      }
+
+      // If it's not a StaggeredGridTile, just wrap the widget directly.
+      return buildWithOverlay(original);
+    });
+
+    // Use StaggeredGrid.count so callers can still use StaggeredGridTile children.
+    return StaggeredGrid.count(
+      crossAxisCount: crossAxisCount,
+      mainAxisSpacing: mainAxisSpacing,
+      crossAxisSpacing: crossAxisSpacing,
+      children: wrapped,
+    );
+  }
+
+  static StaggeredGridTile? _extractTile(Widget w) {
+    if (w is StaggeredGridTile) return w;
+    if (w is ParentDataWidget<StaggeredGridParentData>) {
+      // ParentDataWidget is what StaggeredGridTile implements; try to reflect.
+      // Best-effort: not all wrappers will expose the tile.
+      return null;
+    }
+    return null;
+  }
+}
+
+class _ControlWrapper extends StatelessWidget {
+  const _ControlWrapper({
+    Key? key,
+    required this.index,
+    required this.child,
+    this.onMoveUp,
+    this.onMoveDown,
+    this.onIncreaseWidth,
+    this.onDecreaseWidth,
+  }) : super(key: key);
+
+  final int index;
+  final Widget child;
+  final VoidCallback? onMoveUp;
+  final VoidCallback? onMoveDown;
+  final VoidCallback? onIncreaseWidth;
+  final VoidCallback? onDecreaseWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(child: child),
+        Positioned(
+          right: 4,
+          top: 4,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (onMoveUp != null)
+                _IconButtonSmall(icon: Icons.arrow_upward, onPressed: onMoveUp!),
+              if (onMoveDown != null)
+                _IconButtonSmall(icon: Icons.arrow_downward, onPressed: onMoveDown!),
+              if (onIncreaseWidth != null)
+                _IconButtonSmall(icon: Icons.add, onPressed: onIncreaseWidth!),
+              if (onDecreaseWidth != null)
+                _IconButtonSmall(icon: Icons.remove, onPressed: onDecreaseWidth!),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _IconButtonSmall extends StatelessWidget {
+  const _IconButtonSmall({Key? key, required this.icon, required this.onPressed})
+      : super(key: key);
+
+  final IconData icon;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 28,
+      height: 28,
+      child: Material(
+        color: Colors.black54,
+        shape: const CircleBorder(),
+        child: IconButton(
+          padding: EdgeInsets.zero,
+          iconSize: 16,
+          icon: Icon(icon, color: Colors.white),
+          onPressed: onPressed,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/reorderable_staggered_grid.dart
+++ b/lib/src/widgets/reorderable_staggered_grid.dart
@@ -173,44 +173,136 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
         children: children,
       );
 
-      // Helper to map a global drop offset into an index. If the offset lies
-      // inside a child, return that child's index. Otherwise return the
-      // nearest child's index or append at end.
-      int _indexForGlobalOffset(Offset global) {
+      // Compute insertion index using a cell-fitting skyline algorithm so
+      // dropping into empty spaces places the dragged tile where it fits and
+      // other tiles reflow around it.
+      int _indexForGlobalOffset(Offset global, int draggedIndex) {
         final gridBox = context.findRenderObject() as RenderBox?;
         if (gridBox == null) return widget.children.length;
+        final gridSize = gridBox.size;
         final local = gridBox.globalToLocal(global);
 
-        for (var i = 0; i < _childKeys.length; i++) {
-          final key = _childKeys[i];
-          final cctx = key.currentContext;
-          if (cctx == null) continue;
-          final render = cctx.findRenderObject() as RenderBox?;
-          if (render == null) continue;
-          final childGlobal = render.localToGlobal(Offset.zero);
-          final childLocal = gridBox.globalToLocal(childGlobal);
-          final rect = childLocal & render.size;
-          if (rect.contains(local)) return i;
-        }
+        final colCount = widget.crossAxisCount;
+        final columnWidth = gridSize.width / colCount;
 
-        double bestDist = double.infinity;
-        int bestIndex = widget.children.length;
+        // Derive a reasonable cell height from existing tiles: use tiles that
+        // declare mainAxisCellCount or infer from their measured height.
+        double? cellHeight;
+        final measuredHeights = <double>[];
         for (var i = 0; i < _childKeys.length; i++) {
           final key = _childKeys[i];
           final cctx = key.currentContext;
           if (cctx == null) continue;
           final render = cctx.findRenderObject() as RenderBox?;
           if (render == null) continue;
-          final childGlobal = render.localToGlobal(Offset.zero);
-          final childLocal = gridBox.globalToLocal(childGlobal);
-          final center = childLocal + Offset(render.size.width / 2, render.size.height / 2);
-          final d = (center - local).distance;
-          if (d < bestDist) {
-            bestDist = d;
-            bestIndex = i;
+          final widgetTile = widget.children[i] is StaggeredGridTile ? widget.children[i] as StaggeredGridTile : null;
+          if (widgetTile != null && widgetTile.mainAxisCellCount != null) {
+            measuredHeights.add(render.size.height / widgetTile.mainAxisCellCount!.toDouble());
+          } else if (widgetTile != null && widgetTile.mainAxisExtent != null) {
+            measuredHeights.add(widgetTile.mainAxisExtent!.toDouble());
+          } else {
+            // fallback: treat square cells
+            measuredHeights.add(render.size.height);
           }
         }
-        return bestIndex;
+        if (measuredHeights.isNotEmpty) {
+          cellHeight = measuredHeights.reduce((a, b) => a + b) / measuredHeights.length;
+        } else {
+          cellHeight = columnWidth; // fallback
+        }
+
+        // Helper to get spans for a given child index
+        int _crossSpanAt(int idx) {
+          final w = widget.children[idx];
+          if (w is StaggeredGridTile) return w.crossAxisCellCount;
+          return 1;
+        }
+
+        int _mainSpanAt(int idx, RenderBox? render) {
+          final w = widget.children[idx];
+          if (w is StaggeredGridTile) {
+            if (w.mainAxisCellCount != null) return w.mainAxisCellCount!.toInt();
+            if (w.mainAxisExtent != null) {
+              return (w.mainAxisExtent! / cellHeight).round().clamp(1, 9999);
+            }
+          }
+          if (render != null) {
+            return (render.size.height / cellHeight).round().clamp(1, 9999);
+          }
+          return 1;
+        }
+
+        // Build a list of items excluding the dragged one in original order.
+        final order = <int>[];
+        for (var i = 0; i < widget.children.length; i++) if (i != draggedIndex) order.add(i);
+
+        // Prepare heights skyline per column (in main-axis cell units)
+        final heights = List<int>.filled(colCount, 0);
+
+        final placed = <int, Map<String, int>>{}; // index -> {'x','y'} positions in cell units
+
+        for (var idx in order) {
+          final key = _childKeys[idx];
+          final cctx = key.currentContext;
+          final render = cctx?.findRenderObject() as RenderBox?;
+          final cross = _crossSpanAt(idx).clamp(1, colCount);
+          final main = _mainSpanAt(idx, render);
+
+          // Find best x where tile can fit (minimize max height)
+          int bestX = 0;
+          int bestY = 1 << 30;
+          for (var x = 0; x <= colCount - cross; x++) {
+            var maxh = 0;
+            for (var c = x; c < x + cross; c++) if (heights[c] > maxh) maxh = heights[c];
+            if (maxh < bestY) {
+              bestY = maxh;
+              bestX = x;
+            }
+          }
+          // Place
+          for (var c = bestX; c < bestX + cross; c++) heights[c] = bestY + main;
+          placed[idx] = {'x': bestX, 'y': bestY};
+        }
+
+        // Determine target column/row under the drop point
+        final targetCol = (local.dx / columnWidth).clamp(0, colCount - 1).floor();
+        final targetRow = (local.dy / cellHeight).floor();
+
+        // Now find where the dragged tile could fit if placed near target.
+        final draggedCross = _crossSpanAt(draggedIndex).clamp(1, colCount);
+
+        // Search for a placement position starting near targetCol and scanning
+        // rows from 0..max to find a spot where columns c..c+draggedCross-1
+        // have heights <= targetRow.
+        int chosenInsertOrderIndex = order.length; // default append
+        bool found = false;
+        final maxRow = (heights.reduce((a, b) => a > b ? a : b) + 20);
+        for (var row = 0; row <= maxRow && !found; row++) {
+          // try columns in order of proximity to targetCol
+          final cols = List<int>.generate(colCount - draggedCross + 1, (i) => i);
+          cols.sort((a, b) => (a - targetCol).abs().compareTo((b - targetCol).abs()));
+          for (var col in cols) {
+            var canFit = true;
+            for (var c = col; c < col + draggedCross; c++) if (heights[c] > row) { canFit = false; break; }
+            if (canFit) {
+              // Determine insertion index: count how many placed items start before
+              // this (row,col) position in layout order
+              int countBefore = 0;
+              for (var idx in order) {
+                final pos = placed[idx]!;
+                if (pos['y']! < row) countBefore++;
+                else if (pos['y']! == row && pos['x']! < col) countBefore++;
+              }
+              chosenInsertOrderIndex = countBefore;
+              found = true;
+              break;
+            }
+          }
+        }
+
+        // Map chosenInsertOrderIndex back to original children index
+        if (chosenInsertOrderIndex >= order.length) return widget.children.length;
+        return order[chosenInsertOrderIndex];
       }
 
       return GestureDetector(

--- a/lib/src/widgets/reorderable_staggered_grid.dart
+++ b/lib/src/widgets/reorderable_staggered_grid.dart
@@ -53,9 +53,19 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
   double _initialWidth = 0.0;
   double _initialHeight = 0.0;
   bool _scalingActive = false;
+  final List<GlobalKey> _childKeys = []; 
 
   @override
   Widget build(BuildContext context) {
+    // Ensure we have a GlobalKey for each child to calculate positions for
+    // empty-space drops.
+    while (_childKeys.length < widget.children.length) {
+      _childKeys.add(GlobalKey());
+    }
+    if (_childKeys.length > widget.children.length) {
+      _childKeys.removeRange(widget.children.length, _childKeys.length);
+    }
+
     final children = List<Widget>.generate(widget.children.length, (i) {
       final original = widget.children[i];
       final inner = original is StaggeredGridTile ? original.child : original;
@@ -126,44 +136,91 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
         ),
       );
 
+      Widget tileWidget;
       if (original is StaggeredGridTile) {
         if (original.mainAxisExtent != null) {
-          return StaggeredGridTile.extent(
+          tileWidget = StaggeredGridTile.extent(
             crossAxisCellCount: original.crossAxisCellCount,
             mainAxisExtent: original.mainAxisExtent!,
             child: draggable,
           );
-        }
-        if (original.mainAxisCellCount != null) {
-          return StaggeredGridTile.count(
+        } else if (original.mainAxisCellCount != null) {
+          tileWidget = StaggeredGridTile.count(
             crossAxisCellCount: original.crossAxisCellCount,
             mainAxisCellCount: original.mainAxisCellCount!,
             child: draggable,
           );
+        } else {
+          tileWidget = StaggeredGridTile.fit(
+            crossAxisCellCount: original.crossAxisCellCount,
+            child: draggable,
+          );
         }
-        return StaggeredGridTile.fit(
-          crossAxisCellCount: original.crossAxisCellCount,
+      } else {
+        tileWidget = StaggeredGridTile.fit(
+          crossAxisCellCount: 1,
           child: draggable,
         );
       }
 
-      return StaggeredGridTile.fit(
-        crossAxisCellCount: 1,
-        child: draggable,
-      );
+      // Wrap each tile with a KeyedSubtree attached to a GlobalKey so we can
+      // map global drop coordinates back to tile positions when dropping into
+      // empty space.
+      return KeyedSubtree(key: _childKeys[i], child: tileWidget);
     });
 
     // Wrap the grid in a LayoutBuilder so we can read its constraints and
     // support pinch-to-resize from the bottom-right corner. The Animated-
     // Container holds the current width (if set by a pinch) so the grid's
-    // children automatically reflow to the new available width.
+    // children automatically reflow to the new available width. Additionally
+    // add a full-area DragTarget to accept drops into empty spaces.
     return LayoutBuilder(builder: (context, constraints) {
-      Widget grid = StaggeredGrid.count(
+      final grid = StaggeredGrid.count(
         crossAxisCount: widget.crossAxisCount,
         mainAxisSpacing: widget.mainAxisSpacing,
         crossAxisSpacing: widget.crossAxisSpacing,
         children: children,
       );
+
+      // Helper to map a global drop offset into an index. If the offset lies
+      // inside a child, return that child's index. Otherwise return the
+      // nearest child's index or append at end.
+      int _indexForGlobalOffset(Offset global) {
+        final gridBox = context.findRenderObject() as RenderBox?;
+        if (gridBox == null) return widget.children.length;
+        final local = gridBox.globalToLocal(global);
+
+        for (var i = 0; i < _childKeys.length; i++) {
+          final key = _childKeys[i];
+          final cctx = key.currentContext;
+          if (cctx == null) continue;
+          final render = cctx.findRenderObject() as RenderBox?;
+          if (render == null) continue;
+          final childGlobal = render.localToGlobal(Offset.zero);
+          final childLocal = gridBox.globalToLocal(childGlobal);
+          final rect = childLocal & render.size;
+          if (rect.contains(local)) return i;
+        }
+
+        double bestDist = double.infinity;
+        int bestIndex = widget.children.length;
+        for (var i = 0; i < _childKeys.length; i++) {
+          final key = _childKeys[i];
+          final cctx = key.currentContext;
+          if (cctx == null) continue;
+          final render = cctx.findRenderObject() as RenderBox?;
+          if (render == null) continue;
+          final childGlobal = render.localToGlobal(Offset.zero);
+          final childLocal = gridBox.globalToLocal(childGlobal);
+          final center = childLocal + Offset(render.size.width / 2, render.size.height / 2);
+          final d = (center - local).distance;
+          if (d < bestDist) {
+            bestDist = d;
+            bestIndex = i;
+          }
+        }
+        return bestIndex;
+      }
 
       return GestureDetector(
         behavior: HitTestBehavior.translucent,
@@ -196,7 +253,46 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
           width: _width ?? constraints.maxWidth,
           duration: const Duration(milliseconds: 120),
           curve: Curves.easeOut,
-          child: grid,
+          child: Stack(
+            children: [
+              grid,
+              // Full-size DragTarget to accept drops into empty areas. It
+              // delegates to per-tile DragTargets if the drop lands on a tile
+              // by refusing (returning false) in that case.
+              Positioned.fill(
+                child: DragTarget<int>(
+                  onWillAcceptWithDetails: (details) {
+                    if (details == null) return false;
+                    final gridBox = context.findRenderObject() as RenderBox?;
+                    if (gridBox == null) return false;
+                    final idx = _indexForGlobalOffset(details.offset);
+                    // If the point is inside an existing child, let that
+                    // child's DragTarget handle it (so return false).
+                    if (idx < _childKeys.length) {
+                      final key = _childKeys[idx];
+                      final cctx = key.currentContext;
+                      if (cctx != null) {
+                        final render = cctx.findRenderObject() as RenderBox?;
+                        if (render != null) {
+                          final childGlobal = render.localToGlobal(Offset.zero);
+                          final childLocal = gridBox.globalToLocal(childGlobal);
+                          final rect = childLocal & render.size;
+                          final local = gridBox.globalToLocal(details.offset);
+                          if (rect.contains(local)) return false;
+                        }
+                      }
+                    }
+                    return true;
+                  },
+                  onAcceptWithDetails: (details) {
+                    final newIndex = _indexForGlobalOffset(details.offset);
+                    widget.onReorder(details.data, newIndex);
+                  },
+                  builder: (context, candidate, rejected) => const SizedBox.expand(),
+                ),
+              ),
+            ],
+          ),
         ),
       );
     });

--- a/lib/src/widgets/reorderable_staggered_grid.dart
+++ b/lib/src/widgets/reorderable_staggered_grid.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_staggered_grid_view/src/rendering/staggered_grid.dart';
 import 'package:flutter_staggered_grid_view/src/widgets/staggered_grid.dart';
 import 'package:flutter_staggered_grid_view/src/widgets/staggered_grid_tile.dart';
 
@@ -6,7 +7,13 @@ import 'package:flutter_staggered_grid_view/src/widgets/staggered_grid_tile.dart
 /// for staggered grid children. Dragging is implemented with LongPressDraggable
 /// and DragTarget; the StaggeredGridTile remains the ParentDataWidget so layout
 /// behavior is preserved.
+/// A staggered grid that supports drag-to-reorder and direct resize gestures.
+///
+/// Reordering is triggered by a long press on a tile. Resizing is handled by a
+/// small resize grip in the corner of each tile. This keeps the grid free of
+/// extra button controls while still enabling the requested behavior.
 class ReorderableStaggeredGrid extends StatefulWidget {
+  /// Creates a staggered grid with drag-to-reorder and resize handles.
   const ReorderableStaggeredGrid({
     Key? key,
     required this.children,
@@ -17,12 +24,23 @@ class ReorderableStaggeredGrid extends StatefulWidget {
     this.crossAxisSpacing = 4.0,
   }) : super(key: key);
 
+  /// The tiles displayed by the grid.
   final List<Widget> children;
+
+  /// Called when a tile is reordered.
   final void Function(int oldIndex, int newIndex) onReorder;
+
+  /// Optional callback triggered when a tile's logical size changes.
   final void Function(int index, int crossAxisCellCount, num? mainAxisCellCount)?
       onResize;
+
+  /// Number of columns in the staggered grid.
   final int crossAxisCount;
+
+  /// Spacing between tiles along the main axis.
   final double mainAxisSpacing;
+
+  /// Spacing between tiles along the cross axis.
   final double crossAxisSpacing;
 
   @override
@@ -30,121 +48,103 @@ class ReorderableStaggeredGrid extends StatefulWidget {
 }
 
 class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
-  int? _draggingIndex;
-
   @override
   Widget build(BuildContext context) {
     final children = List<Widget>.generate(widget.children.length, (i) {
       final original = widget.children[i];
+      final inner = original is StaggeredGridTile ? original.child : original;
 
-      Widget buildDraggableInner(Widget inner) {
-        return LongPressDraggable<int>(
-          data: i,
-          dragAnchorStrategy: pointerDragAnchorStrategy,
-          feedback: Material(
-            elevation: 6,
-            color: Colors.transparent,
-            child: Opacity(
-              opacity: 0.95,
-              child: ConstrainedBox(
-                constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width / widget.crossAxisCount * (original is StaggeredGridTile ? original.crossAxisCellCount.toDouble() : 1)),
-                child: inner,
+      final resizeDelta = widget.onResize == null
+          ? null
+          : (Offset delta) {
+              final tile = _extractTile(original);
+              final currentCross = tile?.crossAxisCellCount ?? 1;
+              final currentMain = tile?.mainAxisCellCount ?? 1;
+              final newCross = (currentCross + (delta.dx / 80).round())
+                  .clamp(1, widget.crossAxisCount);
+              final newMain = (currentMain.toInt() + (delta.dy / 80).round())
+                  .clamp(1, 9999);
+              widget.onResize!(i, newCross, newMain);
+            };
+
+      final tileContent = _ControlWrapper(
+        child: inner,
+        onResizeDelta: resizeDelta,
+      );
+
+      final draggable = LongPressDraggable<int>(
+        data: i,
+        delay: const Duration(milliseconds: 120),
+        dragAnchorStrategy: pointerDragAnchorStrategy,
+        feedback: Material(
+          elevation: 6,
+          color: Colors.transparent,
+          child: Opacity(
+            opacity: 0.95,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                maxWidth: MediaQuery.of(context).size.width /
+                    widget.crossAxisCount *
+                    (original is StaggeredGridTile
+                        ? original.crossAxisCellCount.toDouble()
+                        : 1),
               ),
+              child: tileContent,
             ),
           ),
-          childWhenDragging: Opacity(opacity: 0.0, child: inner),
-          onDragStarted: () => setState(() => _draggingIndex = i),
-          onDraggableCanceled: (_, __) => setState(() => _draggingIndex = null),
-          onDragEnd: (_) => setState(() => _draggingIndex = null),
-          child: inner,
-        );
-      }
-
-      Widget tileWithDragTarget(Widget tileWidget) {
-        return DragTarget<int>(
-          onWillAccept: (from) => from != null && from != i,
-          onAccept: (from) {
-            // Reorder so that dragged item is inserted at the position of this tile
-            widget.onReorder(from, i);
-            setState(() => _draggingIndex = null);
+        ),
+        childWhenDragging: Opacity(opacity: 0.25, child: tileContent),
+        onDragStarted: () {},
+        onDraggableCanceled: (_, __) {},
+        onDragEnd: (_) {},
+        child: DragTarget<int>(
+          onWillAcceptWithDetails: (details) => details.data != i,
+          onAcceptWithDetails: (details) {
+            widget.onReorder(details.data, i);
           },
           builder: (context, candidateData, rejectedData) {
             final hasCandidate = candidateData.isNotEmpty;
             return AnimatedContainer(
               duration: const Duration(milliseconds: 150),
               decoration: hasCandidate
-                  ? BoxDecoration(border: Border.all(color: Theme.of(context).colorScheme.primary, width: 3))
+                  ? BoxDecoration(
+                      border: Border.all(
+                        color: Theme.of(context).colorScheme.primary,
+                        width: 3,
+                      ),
+                    )
                   : null,
-              child: tileWidget,
+              child: tileContent,
             );
           },
+        ),
+      );
+
+      if (original is StaggeredGridTile) {
+        if (original.mainAxisExtent != null) {
+          return StaggeredGridTile.extent(
+            crossAxisCellCount: original.crossAxisCellCount,
+            mainAxisExtent: original.mainAxisExtent!,
+            child: draggable,
+          );
+        }
+        if (original.mainAxisCellCount != null) {
+          return StaggeredGridTile.count(
+            crossAxisCellCount: original.crossAxisCellCount,
+            mainAxisCellCount: original.mainAxisCellCount!,
+            child: draggable,
+          );
+        }
+        return StaggeredGridTile.fit(
+          crossAxisCellCount: original.crossAxisCellCount,
+          child: draggable,
         );
       }
 
-      // If original is a StaggeredGridTile, recreate it and make its inner child draggable.
-      if (original is StaggeredGridTile) {
-        final inner = original.child;
-
-        Widget draggableInner = buildDraggableInner(_ControlWrapper(
-          index: i,
-          child: inner,
-          onIncreaseWidth: widget.onResize == null
-              ? null
-              : () {
-                  final tile = _extractTile(original);
-                  final newCross = (tile?.crossAxisCellCount ?? 1) + 1;
-                  widget.onResize!(i, newCross, tile?.mainAxisCellCount);
-                },
-          onDecreaseWidth: widget.onResize == null
-              ? null
-              : () {
-                  final tile = _extractTile(original);
-                  final newCross = (tile?.crossAxisCellCount ?? 1) - 1;
-                  widget.onResize!(i, newCross < 1 ? 1 : newCross, tile?.mainAxisCellCount);
-                },
-        ));
-
-        final recreated = (original.mainAxisExtent != null)
-            ? StaggeredGridTile.extent(
-                crossAxisCellCount: original.crossAxisCellCount,
-                mainAxisExtent: original.mainAxisExtent!,
-                child: draggableInner,
-              )
-            : (original.mainAxisCellCount != null)
-                ? StaggeredGridTile.count(
-                    crossAxisCellCount: original.crossAxisCellCount,
-                    mainAxisCellCount: original.mainAxisCellCount!,
-                    child: draggableInner,
-                  )
-                : StaggeredGridTile.fit(
-                    crossAxisCellCount: original.crossAxisCellCount,
-                    child: draggableInner,
-                  );
-
-        return tileWithDragTarget(recreated);
-      }
-
-      // For non-tile widgets, just wrap them with draggable + drag target.
-      final nonTileChild = buildDraggableInner(_ControlWrapper(
-        index: i,
-        child: original,
-        onIncreaseWidth: widget.onResize == null
-            ? null
-            : () {
-                final tile = _extractTile(original);
-                final newCross = (tile?.crossAxisCellCount ?? 1) + 1;
-                widget.onResize!(i, newCross, tile?.mainAxisCellCount);
-              },
-        onDecreaseWidth: widget.onResize == null
-            ? null
-            : () {
-                final tile = _extractTile(original);
-                final newCross = (tile?.crossAxisCellCount ?? 1) - 1;
-                widget.onResize!(i, newCross < 1 ? 1 : newCross, tile?.mainAxisCellCount);
-              },
-      ));
-
-      return tileWithDragTarget(nonTileChild);
+      return StaggeredGridTile.fit(
+        crossAxisCellCount: 1,
+        child: draggable,
+      );
     });
 
     return StaggeredGrid.count(
@@ -169,74 +169,63 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
 class _ControlWrapper extends StatelessWidget {
   const _ControlWrapper({
     Key? key,
-    required this.index,
     required this.child,
-    this.onMoveUp,
-    this.onMoveDown,
-    this.onIncreaseWidth,
-    this.onDecreaseWidth,
+    this.onResizeDelta,
   }) : super(key: key);
 
-  final int index;
   final Widget child;
-  final VoidCallback? onMoveUp;
-  final VoidCallback? onMoveDown;
-  final VoidCallback? onIncreaseWidth;
-  final VoidCallback? onDecreaseWidth;
+  final void Function(Offset delta)? onResizeDelta;
 
   @override
   Widget build(BuildContext context) {
+    final resizeHandle = onResizeDelta == null
+        ? null
+        : GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onPanUpdate: (details) => onResizeDelta!(details.delta),
+            child: Container(
+              width: 28,
+              height: 28,
+              decoration: BoxDecoration(
+                color: Colors.black54,
+                borderRadius: BorderRadius.circular(14),
+              ),
+              child: const Icon(
+                Icons.open_in_full,
+                color: Colors.white,
+                size: 16,
+              ),
+            ),
+          );
+
     return Stack(
       children: [
-        Positioned.fill(child: child),
+        // Place the content as a non-positioned child so the Stack can size
+        // itself based on the child's intrinsic dimensions. Using
+        // Positioned.fill here caused unbounded constraints when the widget
+        // was used inside an Overlay (drag feedback), producing a RenderBox
+        // with missing size.
+        child,
         Positioned(
-          right: 4,
-          top: 4,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              // Drag handle indicator
-              Container(
-                width: 28,
-                height: 28,
-                decoration: BoxDecoration(color: Colors.black54, shape: BoxShape.circle),
-                child: const Icon(Icons.drag_handle, color: Colors.white, size: 16),
-              ),
-              const SizedBox(height: 6),
-              if (onIncreaseWidth != null)
-                _IconButtonSmall(icon: Icons.add, onPressed: onIncreaseWidth!),
-              if (onDecreaseWidth != null)
-                _IconButtonSmall(icon: Icons.remove, onPressed: onDecreaseWidth!),
-            ],
+          top: 6,
+          right: 6,
+          child: Container(
+            width: 28,
+            height: 28,
+            decoration: BoxDecoration(
+              color: Colors.black54,
+              borderRadius: BorderRadius.circular(14),
+            ),
+            child: const Icon(Icons.drag_handle, color: Colors.white, size: 16),
           ),
         ),
+        if (resizeHandle != null)
+          Positioned(
+            bottom: 6,
+            right: 6,
+            child: resizeHandle,
+          ),
       ],
-    );
-  }
-}
-
-class _IconButtonSmall extends StatelessWidget {
-  const _IconButtonSmall({Key? key, required this.icon, required this.onPressed})
-      : super(key: key);
-
-  final IconData icon;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: 28,
-      height: 28,
-      child: Material(
-        color: Colors.black54,
-        shape: const CircleBorder(),
-        child: IconButton(
-          padding: EdgeInsets.zero,
-          iconSize: 16,
-          icon: Icon(icon, color: Colors.white),
-          onPressed: onPressed,
-        ),
-      ),
     );
   }
 }

--- a/lib/src/widgets/reorderable_staggered_grid.dart
+++ b/lib/src/widgets/reorderable_staggered_grid.dart
@@ -112,27 +112,18 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
         childWhenDragging: Opacity(opacity: 0.25, child: tileContent),
         onDragStarted: () {},
         onDraggableCanceled: (_, __) {},
-        onDragEnd: (_) {},
-        child: DragTarget<int>(
-          onWillAcceptWithDetails: (details) => details.data != i,
-          onAcceptWithDetails: (details) {
-            widget.onReorder(details.data, i);
-          },
-          builder: (context, candidateData, rejectedData) {
-            final hasCandidate = candidateData.isNotEmpty;
-            return AnimatedContainer(
-              duration: const Duration(milliseconds: 150),
-              decoration: hasCandidate
-                  ? BoxDecoration(
-                      border: Border.all(
-                        color: Theme.of(context).colorScheme.primary,
-                        width: 3,
-                      ),
-                    )
-                  : null,
-              child: tileContent,
-            );
-          },
+        onDragEnd: (_) { setState(() { _hoverIndex = null; }); },
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          decoration: _hoverIndex == i
+              ? BoxDecoration(
+                  border: Border.all(
+                    color: Theme.of(context).colorScheme.primary,
+                    width: 3,
+                  ),
+                )
+              : null,
+          child: tileContent,
         ),
       );
 
@@ -256,37 +247,32 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
           child: Stack(
             children: [
               grid,
-              // Full-size DragTarget to accept drops into empty areas. It
-              // delegates to per-tile DragTargets if the drop lands on a tile
-              // by refusing (returning false) in that case.
+              // Full-size DragTarget to accept drops into empty areas. We
+              // use onMove to update a hover index for visual feedback and
+              // handle acceptance in onAcceptWithDetails.
               Positioned.fill(
                 child: DragTarget<int>(
-                  onWillAcceptWithDetails: (details) {
-                    if (details == null) return false;
-                    final gridBox = context.findRenderObject() as RenderBox?;
-                    if (gridBox == null) return false;
-                    final idx = _indexForGlobalOffset(details.offset);
-                    // If the point is inside an existing child, let that
-                    // child's DragTarget handle it (so return false).
-                    if (idx < _childKeys.length) {
-                      final key = _childKeys[idx];
-                      final cctx = key.currentContext;
-                      if (cctx != null) {
-                        final render = cctx.findRenderObject() as RenderBox?;
-                        if (render != null) {
-                          final childGlobal = render.localToGlobal(Offset.zero);
-                          final childLocal = gridBox.globalToLocal(childGlobal);
-                          final rect = childLocal & render.size;
-                          final local = gridBox.globalToLocal(details.offset);
-                          if (rect.contains(local)) return false;
-                        }
-                      }
-                    }
-                    return true;
+                  onMove: (details) {
+                    setState(() {
+                      _hoverIndex = _indexForGlobalOffset(details.offset);
+                    });
                   },
+                  onLeave: (data) {
+                    setState(() {
+                      _hoverIndex = null;
+                    });
+                  },
+                  onWillAccept: (data) => true,
                   onAcceptWithDetails: (details) {
                     final newIndex = _indexForGlobalOffset(details.offset);
-                    widget.onReorder(details.data, newIndex);
+                    setState(() {
+                      _hoverIndex = null;
+                    });
+                    // Normalize index when removing earlier item
+                    var oldIndex = details.data;
+                    var adjustedNew = newIndex;
+                    if (oldIndex < adjustedNew) adjustedNew = (adjustedNew - 1).clamp(0, widget.children.length - 1);
+                    widget.onReorder(oldIndex, adjustedNew);
                   },
                   builder: (context, candidate, rejected) => const SizedBox.expand(),
                 ),
@@ -297,6 +283,8 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
       );
     });
   }
+
+  int? _hoverIndex;
 
   static StaggeredGridTile? _extractTile(Widget w) {
     if (w is StaggeredGridTile) return w;

--- a/lib/src/widgets/reorderable_staggered_grid.dart
+++ b/lib/src/widgets/reorderable_staggered_grid.dart
@@ -48,6 +48,12 @@ class ReorderableStaggeredGrid extends StatefulWidget {
 }
 
 class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
+  double? _width;
+  double? _height;
+  double _initialWidth = 0.0;
+  double _initialHeight = 0.0;
+  bool _scalingActive = false;
+
   @override
   Widget build(BuildContext context) {
     final children = List<Widget>.generate(widget.children.length, (i) {
@@ -147,12 +153,53 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
       );
     });
 
-    return StaggeredGrid.count(
-      crossAxisCount: widget.crossAxisCount,
-      mainAxisSpacing: widget.mainAxisSpacing,
-      crossAxisSpacing: widget.crossAxisSpacing,
-      children: children,
-    );
+    // Wrap the grid in a LayoutBuilder so we can read its constraints and
+    // support pinch-to-resize from the bottom-right corner. The Animated-
+    // Container holds the current width (if set by a pinch) so the grid's
+    // children automatically reflow to the new available width.
+    return LayoutBuilder(builder: (context, constraints) {
+      Widget grid = StaggeredGrid.count(
+        crossAxisCount: widget.crossAxisCount,
+        mainAxisSpacing: widget.mainAxisSpacing,
+        crossAxisSpacing: widget.crossAxisSpacing,
+        children: children,
+      );
+
+      return GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onScaleStart: (details) {
+          final box = context.findRenderObject() as RenderBox?;
+          if (box == null) return;
+          _initialWidth = box.size.width;
+          _initialHeight = box.size.height;
+          final local = box.globalToLocal(details.focalPoint);
+          // Only start scaling when the gesture begins near the bottom-right
+          // corner (within 48 pixels). This prevents accidental scale when
+          // interacting with tiles.
+          if (local.dx >= _initialWidth - 48 && local.dy >= _initialHeight - 48) {
+            _scalingActive = true;
+          } else {
+            _scalingActive = false;
+          }
+        },
+        onScaleUpdate: (details) {
+          if (!_scalingActive) return;
+          final newW = (_initialWidth * details.scale).clamp(80.0, constraints.maxWidth.isFinite ? constraints.maxWidth : _initialWidth * 3);
+          setState(() {
+            _width = newW;
+          });
+        },
+        onScaleEnd: (_) {
+          _scalingActive = false;
+        },
+        child: AnimatedContainer(
+          width: _width ?? constraints.maxWidth,
+          duration: const Duration(milliseconds: 120),
+          curve: Curves.easeOut,
+          child: grid,
+        ),
+      );
+    });
   }
 
   static StaggeredGridTile? _extractTile(Widget w) {
@@ -178,54 +225,10 @@ class _ControlWrapper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final resizeHandle = onResizeDelta == null
-        ? null
-        : GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onPanUpdate: (details) => onResizeDelta!(details.delta),
-            child: Container(
-              width: 28,
-              height: 28,
-              decoration: BoxDecoration(
-                color: Colors.black54,
-                borderRadius: BorderRadius.circular(14),
-              ),
-              child: const Icon(
-                Icons.open_in_full,
-                color: Colors.white,
-                size: 16,
-              ),
-            ),
-          );
-
-    return Stack(
-      children: [
-        // Place the content as a non-positioned child so the Stack can size
-        // itself based on the child's intrinsic dimensions. Using
-        // Positioned.fill here caused unbounded constraints when the widget
-        // was used inside an Overlay (drag feedback), producing a RenderBox
-        // with missing size.
-        child,
-        Positioned(
-          top: 6,
-          right: 6,
-          child: Container(
-            width: 28,
-            height: 28,
-            decoration: BoxDecoration(
-              color: Colors.black54,
-              borderRadius: BorderRadius.circular(14),
-            ),
-            child: const Icon(Icons.drag_handle, color: Colors.white, size: 16),
-          ),
-        ),
-        if (resizeHandle != null)
-          Positioned(
-            bottom: 6,
-            right: 6,
-            child: resizeHandle,
-          ),
-      ],
-    );
+    // Simplify controls: show only the child contents so the grid appears
+    // without overlay buttons. Drag-to-reorder still works via LongPress-
+    // Draggable on the tile's content. Pinch-to-resize for the entire grid is
+    // handled at the grid level.
+    return child;
   }
 }

--- a/lib/src/widgets/reorderable_staggered_grid.dart
+++ b/lib/src/widgets/reorderable_staggered_grid.dart
@@ -378,8 +378,6 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
     });
   }
 
-  int? _hoverIndex;
-
   static StaggeredGridTile? _extractTile(Widget w) {
     if (w is StaggeredGridTile) return w;
     if (w is ParentDataWidget<StaggeredGridParentData>) {

--- a/lib/src/widgets/reorderable_staggered_grid.dart
+++ b/lib/src/widgets/reorderable_staggered_grid.dart
@@ -178,7 +178,7 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
       // Compute insertion index using a cell-fitting skyline algorithm so
       // dropping into empty spaces places the dragged tile where it fits and
       // other tiles reflow around it.
-      int _indexForGlobalOffset(Offset global, int draggedIndex) {
+      int _indexForGlobalOffset(Offset global, int? draggedIndex) {
         final gridBox = context.findRenderObject() as RenderBox?;
         if (gridBox == null) return widget.children.length;
         final gridSize = gridBox.size;
@@ -271,7 +271,8 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
         final targetRow = (local.dy / cellHeight).floor();
 
         // Now find where the dragged tile could fit if placed near target.
-        final draggedCross = _crossSpanAt(draggedIndex).clamp(1, colCount);
+        final effectiveDraggedIndex = (draggedIndex != null && draggedIndex >= 0 && draggedIndex < widget.children.length) ? draggedIndex : null;
+        final draggedCross = (effectiveDraggedIndex != null) ? _crossSpanAt(effectiveDraggedIndex).clamp(1, colCount) : 1;
 
         // Search for a placement position starting near targetCol and scanning
         // rows from 0..max to find a spot where columns c..c+draggedCross-1
@@ -348,7 +349,7 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
                 child: DragTarget<int>(
                   onMove: (details) {
                     setState(() {
-                      _hoverIndex = _indexForGlobalOffset(details.offset, _draggingIndex ?? -1);
+                      _hoverIndex = _indexForGlobalOffset(details.offset, _draggingIndex);
                     });
                   },
                   onLeave: (data) {
@@ -358,7 +359,7 @@ class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
                   },
                   onWillAccept: (data) => true,
                   onAcceptWithDetails: (details) {
-                    final newIndex = _indexForGlobalOffset(details.offset, details.data);
+                    final newIndex = _indexForGlobalOffset(details.offset, details.data as int?);
                     setState(() {
                       _hoverIndex = null;
                     });

--- a/lib/src/widgets/reorderable_staggered_grid.dart
+++ b/lib/src/widgets/reorderable_staggered_grid.dart
@@ -2,11 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_staggered_grid_view/src/widgets/staggered_grid.dart';
 import 'package:flutter_staggered_grid_view/src/widgets/staggered_grid_tile.dart';
 
-/// A simple helper that provides programmatic reorder/resize controls for
-/// staggered grid children. This is intentionally lightweight: it exposes
-/// onReorder and onResize callbacks so the parent can update the underlying
-/// data and rebuild the grid.
-class ReorderableStaggeredGrid extends StatelessWidget {
+/// A helper that provides drag-and-drop reordering and optional resize callbacks
+/// for staggered grid children. Dragging is implemented with LongPressDraggable
+/// and DragTarget; the StaggeredGridTile remains the ParentDataWidget so layout
+/// behavior is preserved.
+class ReorderableStaggeredGrid extends StatefulWidget {
   const ReorderableStaggeredGrid({
     Key? key,
     required this.children,
@@ -26,71 +26,132 @@ class ReorderableStaggeredGrid extends StatelessWidget {
   final double crossAxisSpacing;
 
   @override
-  Widget build(BuildContext context) {
-    // Wrap each child with simple controls for move up / move down and resize.
-    // If the provided child is a StaggeredGridTile, recreate it and wrap its
-    // inner child so the ParentDataWidget remains the direct child of the
-    // StaggeredGrid (this preserves layout behavior).
-    final wrapped = List<Widget>.generate(children.length, (i) {
-      final original = children[i];
+  _ReorderableStaggeredGridState createState() => _ReorderableStaggeredGridState();
+}
 
-      // Build control overlay to be placed inside the tile's child.
-      Widget buildWithOverlay(Widget inner) {
-        return _ControlWrapper(
+class _ReorderableStaggeredGridState extends State<ReorderableStaggeredGrid> {
+  int? _draggingIndex;
+
+  @override
+  Widget build(BuildContext context) {
+    final children = List<Widget>.generate(widget.children.length, (i) {
+      final original = widget.children[i];
+
+      Widget buildDraggableInner(Widget inner) {
+        return LongPressDraggable<int>(
+          data: i,
+          dragAnchorStrategy: pointerDragAnchorStrategy,
+          feedback: Material(
+            elevation: 6,
+            color: Colors.transparent,
+            child: Opacity(
+              opacity: 0.95,
+              child: ConstrainedBox(
+                constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width / widget.crossAxisCount * (original is StaggeredGridTile ? original.crossAxisCellCount.toDouble() : 1)),
+                child: inner,
+              ),
+            ),
+          ),
+          childWhenDragging: Opacity(opacity: 0.0, child: inner),
+          onDragStarted: () => setState(() => _draggingIndex = i),
+          onDraggableCanceled: (_, __) => setState(() => _draggingIndex = null),
+          onDragEnd: (_) => setState(() => _draggingIndex = null),
+          child: inner,
+        );
+      }
+
+      Widget tileWithDragTarget(Widget tileWidget) {
+        return DragTarget<int>(
+          onWillAccept: (from) => from != null && from != i,
+          onAccept: (from) {
+            // Reorder so that dragged item is inserted at the position of this tile
+            widget.onReorder(from, i);
+            setState(() => _draggingIndex = null);
+          },
+          builder: (context, candidateData, rejectedData) {
+            final hasCandidate = candidateData.isNotEmpty;
+            return AnimatedContainer(
+              duration: const Duration(milliseconds: 150),
+              decoration: hasCandidate
+                  ? BoxDecoration(border: Border.all(color: Theme.of(context).colorScheme.primary, width: 3))
+                  : null,
+              child: tileWidget,
+            );
+          },
+        );
+      }
+
+      // If original is a StaggeredGridTile, recreate it and make its inner child draggable.
+      if (original is StaggeredGridTile) {
+        final inner = original.child;
+
+        Widget draggableInner = buildDraggableInner(_ControlWrapper(
           index: i,
           child: inner,
-          onMoveUp: i > 0 ? () => onReorder(i, i - 1) : null,
-          onMoveDown: i < children.length - 1 ? () => onReorder(i, i + 1) : null,
-          onIncreaseWidth: onResize == null
+          onIncreaseWidth: widget.onResize == null
               ? null
               : () {
                   final tile = _extractTile(original);
                   final newCross = (tile?.crossAxisCellCount ?? 1) + 1;
-                  onResize!(i, newCross, tile?.mainAxisCellCount);
+                  widget.onResize!(i, newCross, tile?.mainAxisCellCount);
                 },
-          onDecreaseWidth: onResize == null
+          onDecreaseWidth: widget.onResize == null
               ? null
               : () {
                   final tile = _extractTile(original);
                   final newCross = (tile?.crossAxisCellCount ?? 1) - 1;
-                  onResize!(i, newCross < 1 ? 1 : newCross, tile?.mainAxisCellCount);
+                  widget.onResize!(i, newCross < 1 ? 1 : newCross, tile?.mainAxisCellCount);
                 },
-        );
+        ));
+
+        final recreated = (original.mainAxisExtent != null)
+            ? StaggeredGridTile.extent(
+                crossAxisCellCount: original.crossAxisCellCount,
+                mainAxisExtent: original.mainAxisExtent!,
+                child: draggableInner,
+              )
+            : (original.mainAxisCellCount != null)
+                ? StaggeredGridTile.count(
+                    crossAxisCellCount: original.crossAxisCellCount,
+                    mainAxisCellCount: original.mainAxisCellCount!,
+                    child: draggableInner,
+                  )
+                : StaggeredGridTile.fit(
+                    crossAxisCellCount: original.crossAxisCellCount,
+                    child: draggableInner,
+                  );
+
+        return tileWithDragTarget(recreated);
       }
 
-      if (original is StaggeredGridTile) {
-        // Recreate the tile with the inner child wrapped by the controls.
-        final inner = original.child;
-        if (original.mainAxisExtent != null) {
-          return StaggeredGridTile.extent(
-            crossAxisCellCount: original.crossAxisCellCount,
-            mainAxisExtent: original.mainAxisExtent!,
-            child: buildWithOverlay(inner),
-          );
-        } else if (original.mainAxisCellCount != null) {
-          return StaggeredGridTile.count(
-            crossAxisCellCount: original.crossAxisCellCount,
-            mainAxisCellCount: original.mainAxisCellCount!,
-            child: buildWithOverlay(inner),
-          );
-        } else {
-          return StaggeredGridTile.fit(
-            crossAxisCellCount: original.crossAxisCellCount,
-            child: buildWithOverlay(inner),
-          );
-        }
-      }
+      // For non-tile widgets, just wrap them with draggable + drag target.
+      final nonTileChild = buildDraggableInner(_ControlWrapper(
+        index: i,
+        child: original,
+        onIncreaseWidth: widget.onResize == null
+            ? null
+            : () {
+                final tile = _extractTile(original);
+                final newCross = (tile?.crossAxisCellCount ?? 1) + 1;
+                widget.onResize!(i, newCross, tile?.mainAxisCellCount);
+              },
+        onDecreaseWidth: widget.onResize == null
+            ? null
+            : () {
+                final tile = _extractTile(original);
+                final newCross = (tile?.crossAxisCellCount ?? 1) - 1;
+                widget.onResize!(i, newCross < 1 ? 1 : newCross, tile?.mainAxisCellCount);
+              },
+      ));
 
-      // If it's not a StaggeredGridTile, just wrap the widget directly.
-      return buildWithOverlay(original);
+      return tileWithDragTarget(nonTileChild);
     });
 
-    // Use StaggeredGrid.count so callers can still use StaggeredGridTile children.
     return StaggeredGrid.count(
-      crossAxisCount: crossAxisCount,
-      mainAxisSpacing: mainAxisSpacing,
-      crossAxisSpacing: crossAxisSpacing,
-      children: wrapped,
+      crossAxisCount: widget.crossAxisCount,
+      mainAxisSpacing: widget.mainAxisSpacing,
+      crossAxisSpacing: widget.crossAxisSpacing,
+      children: children,
     );
   }
 
@@ -134,10 +195,14 @@ class _ControlWrapper extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              if (onMoveUp != null)
-                _IconButtonSmall(icon: Icons.arrow_upward, onPressed: onMoveUp!),
-              if (onMoveDown != null)
-                _IconButtonSmall(icon: Icons.arrow_downward, onPressed: onMoveDown!),
+              // Drag handle indicator
+              Container(
+                width: 28,
+                height: 28,
+                decoration: BoxDecoration(color: Colors.black54, shape: BoxShape.circle),
+                child: const Icon(Icons.drag_handle, color: Colors.white, size: 16),
+              ),
+              const SizedBox(height: 6),
               if (onIncreaseWidth != null)
                 _IconButtonSmall(icon: Icons.add, onPressed: onIncreaseWidth!),
               if (onDecreaseWidth != null)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_staggered_grid_view
 description: Provides a collection of Flutter grids layouts (staggered, masonry, quilted, woven, etc.).
-version: 0.8.0
+version: 0.7.0
 homepage: https://github.com/letsar/flutter_staggered_grid_view
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: flutter_staggered_grid_view
 description: Provides a collection of Flutter grids layouts (staggered, masonry, quilted, woven, etc.).
-version: 0.7.0
+version: 0.8.0
 homepage: https://github.com/letsar/flutter_staggered_grid_view
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=3.7.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.7.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
# Summery:
- Fix RenderBox sizing in drag feedback (remove Positioned.fill in tile wrapper).
- Remove per-tile overlay buttons; tiles show content only; long-press still drags.
- Implement cell-aware placement on drop: simulate skyline packing to find an empty slot that fits the dragged tile and insert it there.
- Track tile RenderBoxes with GlobalKeys and show hover feedback while dragging.

Bug fixes: index/typing guards, hover reset on cancel/end.

## Issue: https://github.com/letsar/flutter_staggered_grid_view/issues/273
